### PR TITLE
pvc metrics required changes added

### DIFF
--- a/ip_pool_address_test.go
+++ b/ip_pool_address_test.go
@@ -21,9 +21,10 @@ package gopowerstore
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (

--- a/nfs_types.go
+++ b/nfs_types.go
@@ -108,6 +108,14 @@ type NFSExport struct {
 	// Local path to a location within the file system.
 	// With NFS, each export must have a unique local path.
 	Path string `json:"path,omitempty"`
+	// Read-Write hosts
+	RWHosts []string `json:"read_write_hosts,omitempty"`
+	// Read-Only hosts
+	ROHosts []string `json:"read_only_hosts,omitempty"`
+	// Read-Write, allow Root hosts
+	RWRootHosts []string `json:"read_write_root_hosts,omitempty"`
+	// Read-Only, allow Roots hosts
+	RORootHosts []string `json:"read_only_root_hosts,omitempty"`
 }
 
 // Details about the file interface
@@ -120,7 +128,7 @@ type FileInterface struct {
 
 // Fields returns fields which must be requested to fill struct
 func (n *NFSExport) Fields() []string {
-	return []string{"description", "id", "name", "file_system_id", "default_access", "path"}
+	return []string{"description", "id", "name", "file_system_id", "default_access", "path", "read_only_hosts", "read_only_root_hosts", "read_write_hosts", "read_write_root_hosts"}
 }
 
 // Fields returns fields which must be requested to fill struct


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
Added hosts params for nfs export struct

Unit Tests Results:
go clean -cache
go test -v -coverprofile=c.out ./ ./api
=== RUN   TestClientOptions_Insecure
--- PASS: TestClientOptions_Insecure (0.00s)
=== RUN   TestClientOptions_DefaultTimeout
--- PASS: TestClientOptions_DefaultTimeout (0.00s)
=== RUN   TestClientOptions_RequestIDKey
--- PASS: TestClientOptions_RequestIDKey (0.00s)
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestClientIMPL_SetTraceID
--- PASS: TestClientIMPL_SetTraceID (0.00s)
=== RUN   TestClientIMPL_GetAllRemoteSystems
--- PASS: TestClientIMPL_GetAllRemoteSystems (0.00s)
=== RUN   TestClientIMPL_GetCluster
--- PASS: TestClientIMPL_GetCluster (0.00s)
=== RUN   TestClientIMPL_GetRemoteSystem
--- PASS: TestClientIMPL_GetRemoteSystem (0.00s)
=== RUN   TestClientIMPL_GetRemoteSystemByName
--- PASS: TestClientIMPL_GetRemoteSystemByName (0.00s)
=== RUN   TestClientIMPL_GetFCPorts
--- PASS: TestClientIMPL_GetFCPorts (0.00s)
=== RUN   TestClientIMPL_GetFCPort
--- PASS: TestClientIMPL_GetFCPort (0.00s)
=== RUN   TestClientIMPL_GetNASByName
--- PASS: TestClientIMPL_GetNASByName (0.00s)
=== RUN   TestClientIMPL_GetFSByName
--- PASS: TestClientIMPL_GetFSByName (0.00s)
=== RUN   TestClientIMPL_GetFS
--- PASS: TestClientIMPL_GetFS (0.00s)
=== RUN   TestClientIMPL_CreateFS
--- PASS: TestClientIMPL_CreateFS (0.00s)
=== RUN   TestClientIMPL_CloneFS
--- PASS: TestClientIMPL_CloneFS (0.00s)
=== RUN   TestClientIMPL_DeleteFS
--- PASS: TestClientIMPL_DeleteFS (0.00s)
=== RUN   TestClientIMPL_ModifyFS
--- PASS: TestClientIMPL_ModifyFS (0.00s)
=== RUN   TestClientIMPL_CreateNAS
--- PASS: TestClientIMPL_CreateNAS (0.00s)
=== RUN   TestClientIMPL_DeleteNAS
--- PASS: TestClientIMPL_DeleteNAS (0.00s)
=== RUN   TestAPIError_VolumeNameIsAlreadyUse
--- PASS: TestAPIError_VolumeNameIsAlreadyUse (0.00s)
=== RUN   TestAPIError_VolumeIsNotExist
--- PASS: TestAPIError_VolumeIsNotExist (0.00s)
=== RUN   TestAPIError_HostIsNotAttachedToVolume
--- PASS: TestAPIError_HostIsNotAttachedToVolume (0.00s)
=== RUN   TestAPIError_VolumeAttachedToHost
--- PASS: TestAPIError_VolumeAttachedToHost (0.00s)
=== RUN   TestClientIMPL_GetHosts
--- PASS: TestClientIMPL_GetHosts (0.00s)
=== RUN   TestClientIMPL_GetHost
--- PASS: TestClientIMPL_GetHost (0.00s)
=== RUN   TestClientIMPL_GetHostByName
--- PASS: TestClientIMPL_GetHostByName (0.00s)
=== RUN   TestClientIMPL_CreateHost
--- PASS: TestClientIMPL_CreateHost (0.00s)
=== RUN   TestClientIMPL_DeleteHost
--- PASS: TestClientIMPL_DeleteHost (0.00s)
=== RUN   TestClientIMPL_ModifyHost
--- PASS: TestClientIMPL_ModifyHost (0.00s)
=== RUN   TestClientIMPL_GetHostVolumeMappings
--- PASS: TestClientIMPL_GetHostVolumeMappings (0.00s)
=== RUN   TestClientIMPL_GetHostVolumeMapping
--- PASS: TestClientIMPL_GetHostVolumeMapping (0.00s)
=== RUN   TestClientIMPL_AttachVolumeToHost
--- PASS: TestClientIMPL_AttachVolumeToHost (0.00s)
=== RUN   TestClientIMPL_DetachVolumeFromHost
--- PASS: TestClientIMPL_DetachVolumeFromHost (0.00s)
=== RUN   TestClientIMPL_GetIPPoolAddress
--- PASS: TestClientIMPL_GetIPPoolAddress (0.00s)
=== RUN   TestClientIMPL_GetIPPoolAddress_NotFound
--- PASS: TestClientIMPL_GetIPPoolAddress_NotFound (0.00s)
=== RUN   TestClientIMPL_GetCapacity
--- PASS: TestClientIMPL_GetCapacity (0.00s)
=== RUN   TestClientIMPL_GetCapacity_Zero
--- PASS: TestClientIMPL_GetCapacity_Zero (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByAppliance
--- PASS: TestClientIMPL_PerformanceMetricsByAppliance (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByNode
--- PASS: TestClientIMPL_PerformanceMetricsByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByVolume
--- PASS: TestClientIMPL_PerformanceMetricsByVolume (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByCluster
--- PASS: TestClientIMPL_PerformanceMetricsByCluster (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByVM
--- PASS: TestClientIMPL_PerformanceMetricsByVM (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByVg
--- PASS: TestClientIMPL_PerformanceMetricsByVg (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByFeFcPort
--- PASS: TestClientIMPL_PerformanceMetricsByFeFcPort (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByFeEthPort
--- PASS: TestClientIMPL_PerformanceMetricsByFeEthPort (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByFeEthNode
--- PASS: TestClientIMPL_PerformanceMetricsByFeEthNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByFeFcNode
--- PASS: TestClientIMPL_PerformanceMetricsByFeFcNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsByFileSystem
--- PASS: TestClientIMPL_PerformanceMetricsByFileSystem (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmbByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmbByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricSmbBuiltinclientByNode
--- PASS: TestClientIMPL_PerformanceMetricSmbBuiltinclientByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmbBranchCacheByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmbBranchCacheByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmb1ByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmb1ByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmb1BuiltinclientByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmb1BuiltinclientByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmb2ByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmb2ByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsSmb2BuiltinclientByNode
--- PASS: TestClientIMPL_PerformanceMetricsSmb2BuiltinclientByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsNfsByNode
--- PASS: TestClientIMPL_PerformanceMetricsNfsByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsNfsv3ByNode
--- PASS: TestClientIMPL_PerformanceMetricsNfsv3ByNode (0.00s)
=== RUN   TestClientIMPL_PerformanceMetricsNfsv4ByNode
--- PASS: TestClientIMPL_PerformanceMetricsNfsv4ByNode (0.00s)
=== RUN   TestClientIMPL_WearMetricsByDrive
--- PASS: TestClientIMPL_WearMetricsByDrive (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByCluster
--- PASS: TestClientIMPL_SpaceMetricsByCluster (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByAppliance
--- PASS: TestClientIMPL_SpaceMetricsByAppliance (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByVolume
--- PASS: TestClientIMPL_SpaceMetricsByVolume (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByVolumeFamily
--- PASS: TestClientIMPL_SpaceMetricsByVolumeFamily (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByVM
--- PASS: TestClientIMPL_SpaceMetricsByVM (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByStorageContainer
--- PASS: TestClientIMPL_SpaceMetricsByStorageContainer (0.00s)
=== RUN   TestClientIMPL_SpaceMetricsByVolumeGroup
--- PASS: TestClientIMPL_SpaceMetricsByVolumeGroup (0.00s)
=== RUN   TestClientIMPL_CopyMetricsByAppliance
--- PASS: TestClientIMPL_CopyMetricsByAppliance (0.00s)
=== RUN   TestClientIMPL_CopyMetricsByCluster
--- PASS: TestClientIMPL_CopyMetricsByCluster (0.00s)
=== RUN   TestClientIMPL_CopyMetricsByVolumeGroup
--- PASS: TestClientIMPL_CopyMetricsByVolumeGroup (0.00s)
=== RUN   TestClientIMPL_CopyMetricsByRemoteSystem
--- PASS: TestClientIMPL_CopyMetricsByRemoteSystem (0.00s)
=== RUN   TestClientIMPL_CopyMetricsByVolume
--- PASS: TestClientIMPL_CopyMetricsByVolume (0.00s)
=== RUN   TestClientIMPL_GetNFSExportByName
--- PASS: TestClientIMPL_GetNFSExportByName (0.00s)
=== RUN   TestClientIMPL_CreateNFSExport
--- PASS: TestClientIMPL_CreateNFSExport (0.00s)
=== RUN   TestClientIMPL_DeleteNFSExport
--- PASS: TestClientIMPL_DeleteNFSExport (0.00s)
=== RUN   TestClientIMPL_ModifyNFSExport
--- PASS: TestClientIMPL_ModifyNFSExport (0.00s)
=== RUN   TestClientIMPL_CreateNFSServer
--- PASS: TestClientIMPL_CreateNFSServer (0.00s)
=== RUN   TestClientIMPL_CreateProtectionPolicy
--- PASS: TestClientIMPL_CreateProtectionPolicy (0.00s)
=== RUN   TestClientIMPL_CreateReplicationRule
--- PASS: TestClientIMPL_CreateReplicationRule (0.00s)
=== RUN   TestClientIMPL_DeleteProtectionPolicy
--- PASS: TestClientIMPL_DeleteProtectionPolicy (0.00s)
=== RUN   TestClientIMPL_DeleteReplicationRule
--- PASS: TestClientIMPL_DeleteReplicationRule (0.00s)
=== RUN   TestClientIMPL_GetProtectionPolicyByName
--- PASS: TestClientIMPL_GetProtectionPolicyByName (0.00s)
=== RUN   TestClientIMPL_GetReplicationRuleByName
--- PASS: TestClientIMPL_GetReplicationRuleByName (0.00s)
=== RUN   TestClientIMPL_GetReplicationSessionByLocalResourceID
--- PASS: TestClientIMPL_GetReplicationSessionByLocalResourceID (0.00s)
=== RUN   TestClientIMPL_CreateVolumeGroup
--- PASS: TestClientIMPL_CreateVolumeGroup (0.00s)
=== RUN   TestClientIMPL_DeleteVolumeGroup
--- PASS: TestClientIMPL_DeleteVolumeGroup (0.00s)
=== RUN   TestClientIMPL_GetVolumeGroup
--- PASS: TestClientIMPL_GetVolumeGroup (0.00s)
=== RUN   TestClientIMPL_GetVolumeGroupByName
--- PASS: TestClientIMPL_GetVolumeGroupByName (0.00s)
=== RUN   TestClientIMPL_GetVolumeGroupsByVolumeID
time="2021-10-20T23:01:25-04:00" level=info msg="{[{3765da74-28a7-49db-a693-10cec1de91f8 volume-group   [] {  [] [] []}}]}"
--- PASS: TestClientIMPL_GetVolumeGroupsByVolumeID (0.00s)
=== RUN   TestClientIMPL_ModifyVolumeGroup
--- PASS: TestClientIMPL_ModifyVolumeGroup (0.00s)
=== RUN   TestClientIMPL_RemoveMembersFromVolumeGroup
--- PASS: TestClientIMPL_RemoveMembersFromVolumeGroup (0.00s)
=== RUN   TestClientIMPL_UpdateVolumeGroupProtectionPolicy
--- PASS: TestClientIMPL_UpdateVolumeGroupProtectionPolicy (0.00s)
=== RUN   TestClientIMPL_GetVolumes
--- PASS: TestClientIMPL_GetVolumes (0.00s)
=== RUN   TestClientIMPL_GetVolume
--- PASS: TestClientIMPL_GetVolume (0.00s)
=== RUN   TestClientIMPL_GetVolumeByName
--- PASS: TestClientIMPL_GetVolumeByName (0.00s)
=== RUN   TestClientIMPL_GetSnapshotsByVolumeID
--- PASS: TestClientIMPL_GetSnapshotsByVolumeID (0.00s)
=== RUN   TestClientIMPL_CreateVolume
--- PASS: TestClientIMPL_CreateVolume (0.00s)
=== RUN   TestClientIMPL_CreateSnapshot
--- PASS: TestClientIMPL_CreateSnapshot (0.00s)
=== RUN   TestClientIMPL_CreateVolumeFromSnapshot
--- PASS: TestClientIMPL_CreateVolumeFromSnapshot (0.00s)
=== RUN   TestClientIMPL_ComputeDifferences
--- PASS: TestClientIMPL_ComputeDifferences (0.00s)
=== RUN   TestClientIMPL_ModifyVolume
--- PASS: TestClientIMPL_ModifyVolume (0.00s)
=== RUN   TestClientIMPL_DeleteSnapshot
--- PASS: TestClientIMPL_DeleteSnapshot (0.00s)
=== RUN   TestClientIMPL_DeleteVolume
--- PASS: TestClientIMPL_DeleteVolume (0.00s)
PASS
coverage: 77.1% of statements
ok      github.com/dell/gopowerstore    0.033s  coverage: 77.1% of statements
=== RUN   TestQueryParams_Select
--- PASS: TestQueryParams_Select (0.00s)
=== RUN   TestQueryParams_Order
--- PASS: TestQueryParams_Order (0.00s)
=== RUN   TestQueryParams_Encode_Empty
--- PASS: TestQueryParams_Encode_Empty (0.00s)
=== RUN   TestQueryParams_Encode
--- PASS: TestQueryParams_Encode (0.00s)
=== RUN   TestQueryParamsOverride
--- PASS: TestQueryParamsOverride (0.00s)
=== RUN   TestQueryParamsChaining
--- PASS: TestQueryParamsChaining (0.00s)
=== RUN   Test_buildError
--- PASS: Test_buildError (0.00s)
=== RUN   Test_buildErrorUnknownFormat
--- PASS: Test_buildErrorUnknownFormat (0.00s)
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestClient_Query
--- PASS: TestClient_Query (0.00s)
=== RUN   TestClientIMPL_prepareRequestURL
--- PASS: TestClientIMPL_prepareRequestURL (0.00s)
=== RUN   TestClientIMPL_updatePaginationInfoInMeta
--- PASS: TestClientIMPL_updatePaginationInfoInMeta (0.00s)
=== RUN   TestClientIMPL_QueryParamsWithFields
--- PASS: TestClientIMPL_QueryParamsWithFields (0.00s)
=== RUN   Test_replaceSensitiveHeaderInfo
=== RUN   Test_replaceSensitiveHeaderInfo/Empty_string
=== RUN   Test_replaceSensitiveHeaderInfo/Token
=== RUN   Test_replaceSensitiveHeaderInfo/Authorization
=== RUN   Test_replaceSensitiveHeaderInfo/Cookie
=== RUN   Test_replaceSensitiveHeaderInfo/Combined
--- PASS: Test_replaceSensitiveHeaderInfo (0.00s)
    --- PASS: Test_replaceSensitiveHeaderInfo/Empty_string (0.00s)
    --- PASS: Test_replaceSensitiveHeaderInfo/Token (0.00s)
    --- PASS: Test_replaceSensitiveHeaderInfo/Authorization (0.00s)
    --- PASS: Test_replaceSensitiveHeaderInfo/Cookie (0.00s)
    --- PASS: Test_replaceSensitiveHeaderInfo/Combined (0.00s)
=== RUN   Test_addMetaData
=== RUN   Test_addMetaData/nil_request_is_a_noop
=== RUN   Test_addMetaData/nil_body_is_a_noop
=== RUN   Test_addMetaData/nil_header_is_updated
=== RUN   Test_addMetaData/header_is_updated
=== RUN   Test_addMetaData/header_is_not_updated
--- PASS: Test_addMetaData (0.00s)
    --- PASS: Test_addMetaData/nil_request_is_a_noop (0.00s)
    --- PASS: Test_addMetaData/nil_body_is_a_noop (0.00s)
    --- PASS: Test_addMetaData/nil_header_is_updated (0.00s)
    --- PASS: Test_addMetaData/header_is_updated (0.00s)
    --- PASS: Test_addMetaData/header_is_not_updated (0.00s)
=== RUN   TestContextTraceId
--- PASS: TestContextTraceId (0.00s)
=== RUN   TestContextTraceIdEmpty
--- PASS: TestContextTraceIdEmpty (0.00s)
=== RUN   TestSemaphore
2021/10/20 23:01:27 lock is acquire failed, timeout expired
--- PASS: TestSemaphore (4.00s)
PASS
coverage: 82.3% of statements
ok      github.com/dell/gopowerstore/api        4.011s  coverage: 82.3% of statements