### PR TITLE
Add VolumeDetachedFromHost function to gopowerstore_types

### DIFF
--- a/gopowerstore_types.go
+++ b/gopowerstore_types.go
@@ -106,6 +106,11 @@ func (err *APIError) VolumeAttachedToHost() bool {
 	return err.StatusCode == http.StatusUnprocessableEntity
 }
 
+// VolumeDetachedFromHost returns true if API error indicate that volume is detached from host
+func (err *APIError) VolumeDetachedFromHost() bool {
+	return err.StatusCode == http.StatusUnprocessableEntity
+}
+
 // HostAlreadyRemovedFromNFSExport returns true if API error indicate that operation can't be complete because
 // host ip already removed from nfs export access
 func (err *APIError) HostAlreadyRemovedFromNFSExport() bool {

--- a/gopowerstore_types_test.go
+++ b/gopowerstore_types_test.go
@@ -47,3 +47,8 @@ func TestAPIError_VolumeAttachedToHost(t *testing.T) {
 	apiError := NewVolumeAttachedToHostError()
 	assert.True(t, apiError.VolumeAttachedToHost())
 }
+
+func TestAPIError_VolumeDetachedFromHost(t *testing.T) {
+	apiError := NewVolumeAttachedToHostError()
+	assert.True(t, apiError.VolumeDetachedFromHost())
+}


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
When the `detachVolumeFromHost` API is called multiple times from ControllerUnpublishVolume idempotency is breaking because the array gives two different status codes to handle that Added VolumeDetachedFromHost function in gopowerstore_types to support the idempotency.
