### PR TITLE
Added is_write_order_consistent attribute to volume group

### DIFF
--- a/snapshot_rule_types.go
+++ b/snapshot_rule_types.go
@@ -308,7 +308,7 @@ type SnapshotRule struct {
 
 	ManagedNy_l10n string `json:"managed_by_l10n,omitempty"`
 
-	// todo Policies []PolicyInstance `json:"policies,omitempty"`
+	Policies []ProtectionPolicy `json:"policies,omitempty"`
 }
 
 // Fields returns fields which must be requested to fill struct
@@ -317,6 +317,6 @@ func (s *SnapshotRule) Fields() []string {
 		"interval", "time_of_day", "timezone", "days_of_week", "desired_retention",
 		"is_replica", "nas_access_type", "is_read_only",
 		"managed_by", "managed_by_id",
-		"interval_l10n", "timezone_l10n", "days_of_week_l10n", "nas_access_type_l10n", "managed_by_l10n",
+		"interval_l10n", "timezone_l10n", "days_of_week_l10n", "nas_access_type_l10n", "managed_by_l10n", "policies",
 	}
 }

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -28,6 +28,8 @@ type VolumeGroupCreate struct {
 	Description string `json:"description,omitempty"`
 	// Unique identifier of an optional protection policy to assign to the volume group.
 	ProtectionPolicyID string `json:"protection_policy_id,omitempty"`
+	//For a primary or a clone volume group, this property determines whether snapshot sets of the group will be write order consistent.
+	IsWriteOrderConsistent bool `json:"is_write_order_consistent"`
 	// A list of identifiers of existing volumes that should be added to the volume group.
 	// All the volumes must be on the same Cyclone appliance and should not be part of another volume group.
 	// If a list of volumes is not specified or if the specified list is empty, an
@@ -46,6 +48,8 @@ type VolumeGroup struct {
 	Description string `json:"description,omitempty"`
 	// Unique identifier of the protection policy assigned to the volume.
 	ProtectionPolicyID string `json:"protection_policy_id,omitempty"`
+	//For a primary or a clone volume group, this property determines whether snapshot sets of the group will be write order consistent.
+	IsWriteOrderConsistent bool `json:"is_write_order_consistent,omitempty"`
 	// Volumes provides list of volumes associated to the volume group
 	Volumes []Volume `json:"volume"`
 	// ProtectionPolicy provides snapshot details of the volume or volumeGroup
@@ -56,7 +60,7 @@ type VolumeGroup struct {
 
 // Fields returns fields which must be requested to fill struct
 func (v *VolumeGroup) Fields() []string {
-	return []string{"id", "name", "description", "protection_policy_id", "creation_timestamp"}
+	return []string{"id", "name", "description", "protection_policy_id", "creation_timestamp", "is_write_order_consistent"}
 }
 
 type VolumeGroups struct {


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Common PR Checklist:

- [X] Have you made sure that the code compiles?
- [X] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [X] Have you maintained backward compatibility

## Description of your changes:
Added "is_write_order_consistent" attribute to VolumeGroupCreate and VolumeGroup struct as it is a supported attribute in REST call.