### PR TITLE
Allow empty string for protectionPolicyId for it to be unassigned from VolumeGroup

### DIFF
--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,7 @@ type VolumeGroupMembers struct {
 
 // VolumeGroupModify modifies existing Volume Group
 type VolumeGroupModify struct {
-	// empty to delete
-	ProtectionPolicyId     string  `json:"protection_policy_id,omitempty"`
+	ProtectionPolicyId     string  `json:"protection_policy_id"` // empty to unassign
 	Description            string  `json:"description"`
 	Name                   string  `json:"name,omitempty"`
 	IsWriteOrderConsistent bool    `json:"is_write_order_consistent,omitempty"`


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/928 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Have you maintained backward compatibility

## Description of your changes:

- Reverting the changes w.r.t VolumeGroupModify struct that was made during terraform VolumeGroup updates.
- When modify VG call was sent earlier with empty string for protectionPolicyId, it used to unassign the policy from VG so that the VG can be deleted (for replication).
- Tested the array API and noticed no issues there.

Unit tests:
PASS
        github.com/dell/gopowerstore    coverage: 84.2% of statements
ok      github.com/dell/gopowerstore    0.054s  coverage: 84.2% of statements
...
PASS
        github.com/dell/gopowerstore/api        coverage: 81.9% of statements
ok      github.com/dell/gopowerstore/api        4.030s  coverage: 81.9% of statements
