### PR TITLE
Add session management : Reuse login session across multiple API requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -273,7 +273,6 @@ func (c *ClientIMPL) Query(
 	}
 	defer r.Body.Close() // #nosec G307
 
-	token = r.Header.Get(dellEmcToken)
 	if debug {
 		dump, _ := httputil.DumpResponse(r, true)
 		replacedHeader := prepareHTTPDump(dump) // Replace sensitive parts of response headers
@@ -284,6 +283,9 @@ func (c *ClientIMPL) Query(
 	case resp == nil:
 		return meta, nil
 	case r.StatusCode >= 200 && r.StatusCode < 300:
+		// Save DELL-EMC-TOKEN if it was a successful response.
+		token = r.Header.Get(dellEmcToken)
+
 		c.updatePaginationInfoInMeta(&meta, r)
 		err = json.NewDecoder(r.Body).Decode(resp)
 		if err == io.EOF {

--- a/api/api.go
+++ b/api/api.go
@@ -477,8 +477,8 @@ func (c *ClientIMPL) updatePaginationInfoInMeta(meta *RespMeta, r *http.Response
 }
 
 func prepareHTTPDump(dump []byte) string {
-	// content := replaceSensitiveHeaderInfo(dump)
-	return newlineRegexp.ReplaceAllString(string(dump), " ")
+	content := replaceSensitiveHeaderInfo(dump)
+	return newlineRegexp.ReplaceAllString(content, " ")
 }
 
 var newlineRegexp = regexp.MustCompile(`\r?\n`)

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2020-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -287,8 +287,9 @@ func (c *ClientIMPL) Query(
 		return meta, nil
 	case r.StatusCode >= 200 && r.StatusCode < 300:
 		// Save DELL-EMC-TOKEN if it was a successful response.
-		if len(r.Header.Get(dellEmcToken)) != 0 {
-			c.token = r.Header.Get(dellEmcToken)
+		token := r.Header.Get(dellEmcToken)
+		if len(token) != 0 {
+			c.token = token
 		}
 
 		c.updatePaginationInfoInMeta(&meta, r)

--- a/api/api.go
+++ b/api/api.go
@@ -43,10 +43,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
-var (
-	debug = false
-	token string
-)
+var debug = false
 
 const (
 	paginationHeader = "content-range"
@@ -131,6 +128,7 @@ type ClientIMPL struct {
 	logger            Logger
 	apiThrottle       TimeoutSemaphoreInterface
 	loginMutex        sync.Mutex
+	token             string
 }
 
 // New creates and initialize API client
@@ -292,7 +290,7 @@ func (c *ClientIMPL) Query(
 	case r.StatusCode >= 200 && r.StatusCode < 300:
 		// Save DELL-EMC-TOKEN if it was a successful response.
 		if len(r.Header.Get(dellEmcToken)) != 0 {
-			token = r.Header.Get(dellEmcToken)
+			c.token = r.Header.Get(dellEmcToken)
 		}
 
 		c.updatePaginationInfoInMeta(&meta, r)
@@ -406,8 +404,8 @@ func (c *ClientIMPL) prepareRequest(ctx context.Context, method, requestURL, tra
 	}
 	req = req.WithContext(ctx)
 	req.SetBasicAuth(c.username, c.password)
-	if len(token) != 0 {
-		req.Header.Add(dellEmcToken, token)
+	if len(c.token) != 0 {
+		req.Header.Add(dellEmcToken, c.token)
 	}
 	for key, values := range c.customHTTPHeaders {
 		for _, elem := range values {

--- a/api/api.go
+++ b/api/api.go
@@ -39,8 +39,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/publicsuffix"
 )
 
 var debug = false
@@ -156,7 +154,7 @@ func New(apiURL string, username string,
 	}
 
 	// Set cookie jar to enable session management via auth_cookie
-	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: nil})
 	if err != nil {
 		log.Printf("Failed to set cookie jar. error: %s", err)
 		log.Print("Session management is disabled.")

--- a/api/api.go
+++ b/api/api.go
@@ -180,7 +180,7 @@ func New(apiURL string, username string,
 	}
 
 	// Create a login session after the client is initialized
-	clientImpl.login(context.Background())
+	clientImpl.login(context.Background()) // #nosec G104
 
 	return clientImpl, nil
 }
@@ -300,7 +300,7 @@ func (c *ClientIMPL) Query(
 		}
 		return meta, err
 	case r.StatusCode == http.StatusForbidden:
-		loginResp, _ := c.login(ctx)
+		loginResp, err := c.login(ctx)
 		// Invalid credentials - No need to retry if response of login api was 401 Unauthorized.
 		if err != nil || loginResp.Status == http.StatusUnauthorized {
 			return meta, buildError(r)


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1006 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
Too many login sessions in gopowerstore client causes unexpected session termination in UI. The gopowerstore client is modified to reuse the previous session and not create new sessions every time the REST API is used. This will help cut down on the number of active sessions on the array.

#Tests
 - [x] Built driver image and ran cert-csi multiple times:
 - 23 Oct @ 7:46
   ![image](https://github.com/dell/gopowerstore/assets/109056238/4cde1c03-ffde-4f84-9f0e-3251eb07eb88)
   ![image](https://github.com/dell/gopowerstore/assets/109056238/deb719a9-c7ff-4c7d-be28-51d60b352bbc)

 - 23 Oct @ 9:11
   ![image](https://github.com/dell/gopowerstore/assets/109056238/554737ed-0e81-4639-8742-5490a7c8586a)
   ![image](https://github.com/dell/gopowerstore/assets/109056238/a6352699-cd5e-4769-84c3-591438cef20e)

 - 23 Oct @ 9:30
   ![image](https://github.com/dell/gopowerstore/assets/109056238/29f5e6b9-c7f2-4ef4-b333-47957fccc8c4)
   ![image](https://github.com/dell/gopowerstore/assets/109056238/46ea303f-49cd-4362-94c6-3e32ca0baa3a)

- 25 Oct @ 1:10
   ![image](https://github.com/dell/gopowerstore/assets/109056238/e27eaccb-eb1c-44b9-a892-0861779953bc)
   ![image](https://github.com/dell/gopowerstore/assets/109056238/bbf23f58-c014-4b2b-a15d-1fcd82d3c55a)

