### PR TITLE
Fix Query Parameters for 4.x PowerStores

### DIFF
--- a/replication_types.go
+++ b/replication_types.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,12 +140,12 @@ type ProtectionPolicy struct {
 	PerformanceRules []PerformanceRules `json:"performance_rules"`
 	ReplicationRules []ReplicationRule  `json:"replication_rules"`
 	SnapshotRules    []SnapshotRule     `json:"snapshot_rules"`
-	Volumes          []Volume           `json:"volume"`
-	VolumeGroups     []VolumeGroup      `json:"volume_group"`
+	Volumes          []Volume           `json:"volumes"`
+	VolumeGroups     []VolumeGroup      `json:"volume_groups"`
 }
 
 func (policy *ProtectionPolicy) Fields() []string {
-	return []string{"*", "replication_rules(*)", "snapshot_rules(*)", "virtual_machines(*)", "file_systems(*)", "performance_rules(*)", "volume(*)", "volume_group(*)"}
+	return []string{"*", "replication_rules(*)", "snapshot_rules(*)", "virtual_machines(*)", "file_systems(*)", "performance_rules(*)", "volumes(*)", "volume_groups(*)"}
 }
 
 type StorageElementPair struct {

--- a/volume_group.go
+++ b/volume_group.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ func (c *ClientIMPL) CreateVolumeGroup(ctx context.Context,
 
 func (c *ClientIMPL) GetVolumeGroupsByVolumeID(ctx context.Context, id string) (resp VolumeGroups, err error) {
 	qp := c.API.QueryParams()
-	qp.Select("volume_group.volume_group_membership(id,name,protection_policy_id)")
+	qp.Select("volume_groups(id,name,protection_policy_id)")
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ func (v *VolumeGroup) Fields() []string {
 }
 
 type VolumeGroups struct {
-	VolumeGroup []VolumeGroup `json:"volume_group,omitempty"`
+	VolumeGroup []VolumeGroup `json:"volume_groups,omitempty"`
 }
 
 type VolumeGroupMembers struct {


### PR DESCRIPTION
## Description of your changes:
- Fixes the Query Params to use plural(s) on query parameters which use volumes and volume-groups

**Tested changes against 3.2, 3.5, 3.6 and 4.0 PowerStores**

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Test output
```
PASS: TestVolumeResource (208.68s)
    --- PASS: TestVolumeResource/Create_a_volume (10.56s)
    --- PASS: TestVolumeResource/Destroy_a_volume (3.57s)
    --- PASS: TestVolumeResource/Create_a_volume_with_host (3.25s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_host (3.60s)
    --- PASS: TestVolumeResource/Create_a_volume_with_host_group (3.79s)
    --- PASS: TestVolumeResource/Modify_a_volume_map_a_host_group (3.01s)
    --- PASS: TestVolumeResource/Modify_a_volume_with_host_group_to_remove_volume (3.01s)
    --- PASS: TestVolumeResource/Modify_a_volume_with_host_group_to_remove_host (2.62s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_host_group (3.34s)
    --- PASS: TestVolumeResource/Create_a_volume_with_host_group_name (8.41s)
    --- PASS: TestVolumeResource/Modify_a_volume_with_host_group_name_remove_volume (2.96s)
    --- PASS: TestVolumeResource/Modify_a_volume_with_host_group_name_remove_host (3.05s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_host_group_name (3.32s)
    --- PASS: TestVolumeResource/Create_a_volume_with_blank_name_should_show_error (0.78s)
    --- PASS: TestVolumeResource/Create_a_volume_with_out_a_name_field_should_show_error (0.45s)
    --- PASS: TestVolumeResource/Create_a_volume_with_special_characters_in_the_name (2.16s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_special_characters_in_the_name (2.93s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_really_long_name_should_show_error (2.31s)
    --- PASS: TestVolumeResource/Create_a_volume_with_out_a_size_field_should_show_error (0.44s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_size_should_show_error (1.98s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_host_id (2.79s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_host_group_id (2.93s)
    --- PASS: TestVolumeResource/Create_a_volume_with_host_id_and_host_group_id (2.19s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_host_group_name (2.01s)
    --- PASS: TestVolumeResource/Create_a_volume_with_lun (7.33s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_lun (2.71s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_lun (2.42s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_description (2.63s)
    --- PASS: TestVolumeResource/Destroy_a_volume__with_a_description (3.03s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_blank_description (2.06s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_a_blank_description (3.09s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_really_long_description_should_fail (2.11s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_protection_policy_id (2.41s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_a_protection_policy_id (3.87s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_protection_policy_should_fail (2.16s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_protection_policy_name (2.78s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_a_protection_policy_name (3.21s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_protection_policy_name_should_fail (9.04s)
    --- PASS: TestVolumeResource/Create_a_volume_with_protection_policy_name_and_id_should_fail (1.25s)
    --- PASS: TestVolumeResource/Create_a_volume_with_a_preformance_policy_name (2.49s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_a_preformance_policy_name (3.96s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_preformance_policy_should_fail (0.44s)
    --- PASS: TestVolumeResource/Create_a_volume_with_volume_group_id (2.44s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_volume_group_id (3.48s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_volume_group_id_should_fail (2.11s)
    --- PASS: TestVolumeResource/Create_a_volume_with_volume_group_name (3.24s)
    --- PASS: TestVolumeResource/Remove_a_volume_with_volume_group_name (2.53s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_volume_group_name (3.05s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_volume_group_name_should_fail (2.07s)
    --- PASS: TestVolumeResource/Create_a_volume_with_volume_group_name_and_id_should_fail (1.25s)
    --- PASS: TestVolumeResource/Create_a_volume_with_app_type (7.33s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_app_type (2.83s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_app_type_should_fail (0.76s)
    --- PASS: TestVolumeResource/Create_a_volume_with_app_type_Other (2.15s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_app_type_Other (2.83s)
    --- PASS: TestVolumeResource/Create_a_volume_with_min_size (2.51s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_min_size (2.68s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_min_size_should_fail (2.34s)
    --- PASS: TestVolumeResource/Create_a_volume_with_sector_size (2.38s)
    --- PASS: TestVolumeResource/Destroy_a_volume_with_sector_size (3.00s)
    --- PASS: TestVolumeResource/Create_a_volume_with_invalid_sector_size_should_fail (2.07s)
    --- PASS: TestVolumeResource/Create_a_volume_for_modify_tests (2.44s)
    --- PASS: TestVolumeResource/Modify_a_volume_name (3.27s)
    --- PASS: TestVolumeResource/Modify_a_volume_name_to_blank_should_show_error (4.20s)
    --- PASS: TestVolumeResource/Modify_a_volume_description (2.57s)
    --- PASS: TestVolumeResource/Modify_a_volume_map_a_host (2.71s)
    --- PASS: TestVolumeResource/Modify_a_volume_add_a_protection_policy (3.43s)
    --- PASS: TestVolumeResource/Modify_a_volume_map_a_volume_group (2.99s)
PASS
ok   211.193s
```
**Policy output**
```
--- PASS: TestProtectionPolicyResource (124.55s)
    --- PASS: TestProtectionPolicyResource/Create_protection_policy_with_invalid_replication_rule (7.05s)
    --- PASS: TestProtectionPolicyResource/Create_new_protection_policy_with_non-existing_snapshot_rule_(negative) (2.49s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_Policy_with_""_as_name_(Negative) (0.81s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_Policy_without_name_-_Negative (0.49s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_Policy_without_Snapshot_and_replication_rule_-_Negative (2.14s)
    --- PASS: TestProtectionPolicyResource/Create_protection_policy_with_name_length_greater_than_max_allowed_(Negative) (2.13s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_Policy_without_Snapshot_and_replication_rule_-_Negative#01 (2.84s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_Policy_without_Snapshot_and_replication_rule_-_Negative#02 (2.05s)
    --- PASS: TestProtectionPolicyResource/Create_protection_policy_with_more_than_allowed_number_of_snapshot_rule_-_negative (2.72s)
    --- PASS: TestProtectionPolicyResource/Create_new_protection_policy_with_snapshot_rule (2.82s)
    --- PASS: TestProtectionPolicyResource/Create_new_protection_policy_with_snapshot_rule_Idempotency (1.43s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_non-existing_replication_rule_(Negative) (3.10s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_replication_rule (3.75s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_replication_rule-_idempotency (1.80s)
    --- PASS: TestProtectionPolicyResource/Modify_Protection_policy_-_Remove_existing_replication_rule (1.65s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_snapshot_rule_by_name (7.72s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_snapshot_rule_by_name-_idempotency (1.40s)
    --- PASS: TestProtectionPolicyResource/Modify_Protection_policy_-_Remove_existing_snapshot_rule (2.66s)
    --- PASS: TestProtectionPolicyResource/Modify_Protection_policy_-_Remove_existing_snapshot_rule-idempotency (1.42s)
    --- PASS: TestProtectionPolicyResource/Destroy_new_protection_policy_with_snapshot_rule (3.52s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_policy_with_both_replication_and_snapshot_rule (3.87s)
    --- PASS: TestProtectionPolicyResource/Create_Protection_policy_with_both_replication_and_snapshot_rule#01 (3.96s)
    --- PASS: TestProtectionPolicyResource/Create_new_protection_policy_with_replication_rule (3.00s)
    --- PASS: TestProtectionPolicyResource/Create_new_protection_policy_with_replication_rule_-_Idempotency (1.69s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_change_name-_changed_name_already_present-negative (1.48s)
    --- PASS: TestProtectionPolicyResource/Destroy_Protection_policy_with_both_replication_and_snapshot_rule (3.08s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_change_name (3.31s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_change_name-_idempotency (1.41s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_non-existing_snapshot_rule_(Negative) (6.86s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy-_add_snapshot_rule_by_id (3.26s)
    --- PASS: TestProtectionPolicyResource/Update_protection_policy_with_deleting_snapshot_rule (2.92s)
    --- PASS: TestProtectionPolicyResource/Delete_protection_policy (3.73s)
    --- PASS: TestProtectionPolicyResource/Delete_protection_policy-Idempotency (0.84s)
    --- PASS: TestProtectionPolicyResource/Create_protection_policy_-_add_snapshot_rule_by_id_and_replication_rule_by_name (3.74s)
    --- PASS: TestProtectionPolicyResource/Modify_Protection_policy_-_Remove_all_associated_replication_and_snapshot_rules_(negative) (2.61s)
    --- PASS: TestProtectionPolicyResource/Modify_Protection_policy_-_append_duplicate_snapshot_rule_id (1.59s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy_-_append_duplicate_snapshot_rule_name (2.88s)
    --- PASS: TestProtectionPolicyResource/Modify_protection_policy_-_append_duplicate_replication_rule_name (1.73s)
PASS
ok     152.922s
```


