### PR TITLE
Add metro_replication_session_id to VolumeGroup data

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,6 +192,7 @@ type Client interface {
 	ConfigureMetroVolume(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
 	ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
+	EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error)
 }
 
 // ClientIMPL provides basic API client implementation

--- a/client.go
+++ b/client.go
@@ -190,6 +190,7 @@ type Client interface {
 	GetVolumeGroupSnapshotByName(ctx context.Context, snapName string) (VolumeGroup, error)
 	GetMaxVolumeSize(ctx context.Context) (int64, error)
 	ConfigureMetroVolume(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
+	ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.mongodb.org/mongo-driver v1.16.1 // indirect
+	go.mongodb.org/mongo-driver v1.17.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
+go.mongodb.org/mongo-driver v1.17.0 h1:Hp4q2MCjvY19ViwimTs00wHi7G4yzxh4/2+nTx8r40k=
+go.mongodb.org/mongo-driver v1.17.0/go.mod h1:wwWm/+BuOddhcq3n68LKRmgk2wXzmF6s0SFOa0GINL4=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/inttests/metrics_test.go
+++ b/inttests/metrics_test.go
@@ -163,22 +163,25 @@ func Test_PerformanceMetricsSmb2BuiltinclientByNode(t *testing.T) {
 func Test_PerformanceMetricsNfsByNode(t *testing.T) {
 	resp, err := C.PerformanceMetricsNfsByNode(context.Background(), "N1", gopowerstore.FiveMins)
 	checkAPIErr(t, err)
-	assert.NotEmpty(t, resp)
-	assert.Equal(t, "performance_metrics_nfs_by_node", resp[0].Entity)
+	if assert.NotEmpty(t, resp) {
+		assert.Equal(t, "performance_metrics_nfs_by_node", resp[0].Entity)
+	}
 }
 
 func Test_PerformanceMetricsNfsv3ByNode(t *testing.T) {
 	resp, err := C.PerformanceMetricsNfsv3ByNode(context.Background(), "N1", gopowerstore.FiveMins)
 	checkAPIErr(t, err)
-	assert.NotEmpty(t, resp)
-	assert.Equal(t, "performance_metrics_nfsv3_by_node", resp[0].Entity)
+	if assert.NotEmpty(t, resp) {
+		assert.Equal(t, "performance_metrics_nfsv3_by_node", resp[0].Entity)
+	}
 }
 
 func Test_PerformanceMetricsNfsv4ByNode(t *testing.T) {
 	resp, err := C.PerformanceMetricsNfsv4ByNode(context.Background(), "N1", gopowerstore.FiveMins)
 	checkAPIErr(t, err)
-	assert.NotEmpty(t, resp)
-	assert.Equal(t, "performance_metrics_nfsv4_by_node", resp[0].Entity)
+	if assert.NotEmpty(t, resp) {
+		assert.Equal(t, "performance_metrics_nfsv4_by_node", resp[0].Entity)
+	}
 }
 
 func Test_WearMetricsByDrive(t *testing.T) {

--- a/inttests/volume_group_test.go
+++ b/inttests/volume_group_test.go
@@ -153,13 +153,13 @@ func (s *MetroVolumeGroupTestSuite) TearDownTest() {
 	// TODO: END METRO VOLUME GROUP
 
 	// Delete all the volumes in the volume group
-	// err := s.deleteAllVolumesInVG()
-	// if err != nil {
-	// 	s.T().Logf("%s Please delete from PowerStore when tests complete.", err.Error())
-	// }
+	err := s.deleteAllVolumesInVG()
+	if err != nil {
+		s.T().Logf("%s Please delete from PowerStore when tests complete.", err.Error())
+	}
 
 	// Delete the volume group from the previous test.
-	_, err := s.client.DeleteVolumeGroup(context.Background(), s.vg.this.ID)
+	_, err = s.client.DeleteVolumeGroup(context.Background(), s.vg.this.ID)
 	if err != nil {
 		// 404 status means it was already deleted.
 		// warn about other errors encountered while deleting

--- a/inttests/volume_group_test.go
+++ b/inttests/volume_group_test.go
@@ -1,0 +1,149 @@
+/*
+ *
+ * Copyright © 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package inttests
+
+import (
+	"context"
+	"testing"
+
+	g "github.com/dell/gopowerstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	VGName string = "csi_test_vg"
+)
+
+type VolumeGroupTestSuite struct {
+	suite.Suite
+
+	client  g.Client
+	request g.VolumeGroup
+
+	// Assurance that a volume group exists for the tests.
+	assurance g.CreateResponse
+}
+
+func TestVolumeGroupSuite(t *testing.T) {
+	suite.Run(t, new(VolumeGroupTestSuite))
+}
+
+func (s *VolumeGroupTestSuite) SetupSuite() {
+	s.client = GetNewClient()
+
+	var err error
+	// Make sure a volume group exists on which we can run tests against.
+	s.assurance, err = s.client.CreateVolumeGroup(context.Background(), &g.VolumeGroupCreate{
+		Name:                   VGName,
+		IsWriteOrderConsistent: false,
+	})
+	assert.NoError(s.T(), err)
+}
+
+func (s *VolumeGroupTestSuite) TearDownSuite() {
+	// Delete the volume group we created for the test
+	_, err := s.client.DeleteVolumeGroup(context.Background(), s.assurance.ID)
+	assert.NoError(s.T(), err)
+}
+
+func (s *VolumeGroupTestSuite) SetupTest() {
+}
+
+func (s *VolumeGroupTestSuite) TearDownTest() {
+}
+
+// Returns true if one of the volume groups in vgs has an ID matching
+// the ID provided by id and false if none of the volume groups have
+// a matching ID.
+func containsVolumeGroupID(vgs []g.VolumeGroup, id string) bool {
+	for _, vg := range vgs {
+		if vg.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// Happy path test.
+func (s *VolumeGroupTestSuite) TestGetVolumeGroups() {
+	resp, err := s.client.GetVolumeGroups(context.Background())
+
+	if assert.NoError(s.T(), err) {
+		assert.True(s.T(), containsVolumeGroupID(resp, s.assurance.ID))
+	}
+}
+
+type MetroVolumeGroupTestSuite struct {
+	suite.Suite
+
+	client        g.Client
+	volumeGroupID string
+
+	metro struct {
+		config g.MetroConfig
+	}
+}
+
+func TestMetroVolumeGroupSuite(t *testing.T) {
+	suite.Run(t, new(MetroVolumeGroupTestSuite))
+}
+
+func (s *MetroVolumeGroupTestSuite) SetupSuite() {
+	s.client = GetNewClient()
+
+	// Get a remote system configured for metro replication
+	remoteSystem := GetRemoteSystemForMetro(s.client, s.T())
+	if remoteSystem.ID == "" {
+		s.T().Skip("Could not get a remote system configured for metro. Skipping test suite...")
+	}
+
+	s.metro.config = g.MetroConfig{RemoteSystemID: remoteSystem.ID}
+
+	// Create a volume group to run tests against
+	resp, err := s.client.CreateVolumeGroup(context.Background(), &g.VolumeGroupCreate{
+		Name:                   VGName,
+		IsWriteOrderConsistent: false,
+	})
+	assert.NoError(s.T(), err)
+
+	s.volumeGroupID = resp.ID
+}
+
+func (s *MetroVolumeGroupTestSuite) TearDownSuite() {
+	// Delete the volume group when tests are finished
+	_, err := s.client.DeleteVolumeGroup(context.Background(), s.volumeGroupID)
+	if err != nil {
+		s.T().Log("Unable to delete volume group. Please manually delete the volume group on the PowerStore array.")
+	}
+}
+
+func (s *MetroVolumeGroupTestSuite) SetupTest() {
+}
+
+func (s *MetroVolumeGroupTestSuite) TearDownTest() {
+}
+
+func (s *MetroVolumeGroupTestSuite) TestConfigureMetroVolumeGroup() {
+	// Should configure a metro volume group without errors.
+	resp, err := s.client.ConfigureMetroVolumeGroup(context.Background(), s.volumeGroupID, &s.metro.config)
+
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), resp)
+}

--- a/inttests/volume_group_test.go
+++ b/inttests/volume_group_test.go
@@ -220,6 +220,19 @@ func (s *MetroVolumeGroupTestSuite) TestConfigureMetroVolumeGroup() {
 	assert.NotEmpty(s.T(), resp)
 }
 
+// Make sure GetVolumeGroup returns the metro_replication_session_id
+func (s *MetroVolumeGroupTestSuite) TestGetMetroVGSessionFromVG() {
+	resp, err := s.client.ConfigureMetroVolumeGroup(context.Background(), s.vg.this.ID, &s.metro.config)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), resp)
+
+	// Get the metro_replication_session_id from the Volume Group
+	vg, err := s.client.GetVolumeGroup(context.Background(), s.vg.this.ID)
+
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), resp.ID, vg.MetroReplicationSessionID)
+}
+
 // Try to configure metro on a volume group without any volumes in it.
 func (s *MetroVolumeGroupTestSuite) TestConfigMetroVGOnEmptyVG() {
 	// Delete all the volumes from the volume group.

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -235,6 +235,34 @@ func (_m *Client) ConfigureMetroVolume(ctx context.Context, id string, config *g
 	return r0, r1
 }
 
+// ConfigureMetroVolumeGroup provides a mock function with given fields: ctx, id, config
+func (_m *Client) ConfigureMetroVolumeGroup(ctx context.Context, id string, config *gopowerstore.MetroConfig) (gopowerstore.MetroSessionResponse, error) {
+	ret := _m.Called(ctx, id, config)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConfigureMetroVolumeGroup")
+	}
+
+	var r0 gopowerstore.MetroSessionResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gopowerstore.MetroConfig) (gopowerstore.MetroSessionResponse, error)); ok {
+		return rf(ctx, id, config)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gopowerstore.MetroConfig) gopowerstore.MetroSessionResponse); ok {
+		r0 = rf(ctx, id, config)
+	} else {
+		r0 = ret.Get(0).(gopowerstore.MetroSessionResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gopowerstore.MetroConfig) error); ok {
+		r1 = rf(ctx, id, config)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CopyMetricsByAppliance provides a mock function with given fields: ctx, entityID, interval
 func (_m *Client) CopyMetricsByAppliance(ctx context.Context, entityID string, interval gopowerstore.MetricsIntervalEnum) ([]gopowerstore.CopyMetricsByApplianceResponse, error) {
 	ret := _m.Called(ctx, entityID, interval)
@@ -1301,6 +1329,34 @@ func (_m *Client) EndMetroVolume(ctx context.Context, id string, options *gopowe
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, *gopowerstore.EndMetroVolumeOptions) error); ok {
+		r1 = rf(ctx, id, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EndMetroVolumeGroup provides a mock function with given fields: ctx, id, options
+func (_m *Client) EndMetroVolumeGroup(ctx context.Context, id string, options *gopowerstore.EndMetroVolumeGroupOptions) (gopowerstore.EmptyResponse, error) {
+	ret := _m.Called(ctx, id, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EndMetroVolumeGroup")
+	}
+
+	var r0 gopowerstore.EmptyResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gopowerstore.EndMetroVolumeGroupOptions) (gopowerstore.EmptyResponse, error)); ok {
+		return rf(ctx, id, options)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *gopowerstore.EndMetroVolumeGroupOptions) gopowerstore.EmptyResponse); ok {
+		r0 = rf(ctx, id, options)
+	} else {
+		r0 = ret.Get(0).(gopowerstore.EmptyResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *gopowerstore.EndMetroVolumeGroupOptions) error); ok {
 		r1 = rf(ctx, id, options)
 	} else {
 		r1 = ret.Error(1)

--- a/volume_group.go
+++ b/volume_group.go
@@ -297,3 +297,9 @@ func (c *ClientIMPL) GetVolumeGroupSnapshotByName(ctx context.Context, name stri
 	}
 	return volGroupList[0], err
 }
+
+// ConfigureMetroVolumeGroup configures the volume group provided by id for metro replication using the
+// configuration supplied by config and returns a MetroSessionResponse containing a replication session ID.
+func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error) {
+	return resp, err
+}

--- a/volume_group.go
+++ b/volume_group.go
@@ -319,7 +319,7 @@ func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, c
 
 // EndMetroVolumeGroup ends a metro configuration from a volume group and keeps both volume groups by default. The local copy
 // will retain its SCSI Identities while the remote volume group members will get new SCSI Identities if kept.
-func (c *ClientIMPL) EndMetroVolumeGroup(ctx context.Context, id string, config *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error) {
+func (c *ClientIMPL) EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
@@ -327,7 +327,7 @@ func (c *ClientIMPL) EndMetroVolumeGroup(ctx context.Context, id string, config 
 			Endpoint: volumeGroupURL,
 			ID:       id,
 			Action:   actionEndMetro,
-			Body:     config,
+			Body:     options,
 		},
 		&resp)
 

--- a/volume_group.go
+++ b/volume_group.go
@@ -28,6 +28,7 @@ const (
 	volumeGroupURL    = "volume_group"
 	snapshotURL       = "/snapshot"
 	actionConfigMetro = "configure_metro"
+	actionEndMetro    = "end_metro"
 )
 
 func getVolumeGroupDefaultQueryParams(c Client) api.QueryParamsEncoder {
@@ -301,7 +302,7 @@ func (c *ClientIMPL) GetVolumeGroupSnapshotByName(ctx context.Context, name stri
 
 // ConfigureMetroVolumeGroup configures the volume group provided by id for metro replication using the
 // configuration supplied by config and returns a MetroSessionResponse containing a replication session ID.
-func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error) {
+func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (session MetroSessionResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
@@ -311,9 +312,24 @@ func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, c
 			Action:   actionConfigMetro,
 			Body:     config,
 		},
+		&session)
+
+	return session, WrapErr(err)
+}
+
+// EndMetroVolumeGroup ends a metro configuration from a volume group and keeps both volume groups by default. The local copy
+// will retain its SCSI Identities while the remote volume group members will get new SCSI Identities if kept.
+func (c *ClientIMPL) EndMetroVolumeGroup(ctx context.Context, id string, config *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error) {
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:   "POST",
+			Endpoint: volumeGroupURL,
+			ID:       id,
+			Action:   actionEndMetro,
+			Body:     config,
+		},
 		&resp)
 
 	return resp, WrapErr(err)
-}
-
 }

--- a/volume_group.go
+++ b/volume_group.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	volumeGroupURL = "volume_group"
-	snapshotURL    = "/snapshot"
+	volumeGroupURL    = "volume_group"
+	snapshotURL       = "/snapshot"
+	actionConfigMetro = "configure_metro"
 )
 
 func getVolumeGroupDefaultQueryParams(c Client) api.QueryParamsEncoder {
@@ -301,5 +302,18 @@ func (c *ClientIMPL) GetVolumeGroupSnapshotByName(ctx context.Context, name stri
 // ConfigureMetroVolumeGroup configures the volume group provided by id for metro replication using the
 // configuration supplied by config and returns a MetroSessionResponse containing a replication session ID.
 func (c *ClientIMPL) ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error) {
-	return resp, err
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:   "POST",
+			Endpoint: volumeGroupURL,
+			ID:       id,
+			Action:   actionConfigMetro,
+			Body:     config,
+		},
+		&resp)
+
+	return resp, WrapErr(err)
+}
+
 }

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -131,3 +131,15 @@ type VolumeGroupSnapshotCreate struct {
 	// ExpirationTimestamp provides volume group creation time
 	ExpirationTimestamp string `json:"expiration_timestamp,omitempty"`
 }
+
+// EndMetroVolumeGroupOptions provides options for deleting the remote volume group and forcing the deletion.
+type EndMetroVolumeGroupOptions struct {
+	// DeleteRemoteVolumeGroup specifies whether or not to delete the remote volume group when ending the metro session.
+	DeleteRemoteVolumeGroup bool `json:"delete_remote_volume_group,omitempty"`
+	// ForceDelete specifies if the Metro volume group should be forcefully deleted.
+	// If the force option is specified, any errors returned while attempting to tear down the remote side of the
+	// metro session will be ignored and the remote side may be left in an indeterminate state.
+	// If any errors occur on the local side the operation can still fail.
+	// It is not recommended to use this option unless the remote side is known to be down.
+	ForceDelete bool `json:"force,omitempty"`
+}

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -86,6 +86,8 @@ type VolumeGroup struct {
 	LocationHistory []LocationHistory `json:"location_history,omitempty"`
 	//  This resource type has queriable associations from virtual_volume, volume, volume_group, replication_session
 	MigrationSession MigrationSession `json:"migration_session,omitempty"`
+	// Unique identifier of the replication session assigned to the volume group if it has been configured as a metro volume group between two PowerStore clusters.
+	MetroReplicationSessionID string `json:"metro_replication_session_id,omitempty"`
 }
 
 // Fields returns fields which must be requested to fill struct

--- a/volume_types.go
+++ b/volume_types.go
@@ -415,15 +415,3 @@ type EndMetroVolumeOptions struct {
 	// It is not recommended to use this option unless the remote side is known to be down.
 	ForceDelete bool `json:"force,omitempty"`
 }
-
-// EndMetroVolumeGroupOptions provides options for deleting the remote volume group and forcing the deletion.
-type EndMetroVolumeGroupOptions struct {
-	// DeleteRemoteVolumeGroup specifies whether or not to delete the remote volume group when ending the metro session.
-	DeleteRemoteVolumeGroup bool `json:"delete_remote_volume_group,omitempty"`
-	// ForceDelete specifies if the Metro volume group should be forcefully deleted.
-	// If the force option is specified, any errors returned while attempting to tear down the remote side of the
-	// metro session will be ignored and the remote side may be left in an indeterminate state.
-	// If any errors occur on the local side the operation can still fail.
-	// It is not recommended to use this option unless the remote side is known to be down.
-	ForceDelete bool `json:"force,omitempty"`
-}

--- a/volume_types.go
+++ b/volume_types.go
@@ -404,11 +404,23 @@ type MetroSessionResponse struct {
 	ID string `json:"metro_replication_session_id,omitempty"`
 }
 
-// EndMetroVolumeOptions defines the options associated with deleting a metro volume.
+// EndMetroVolumeOptions provides options for deleting the remote volume and forcing the deletion.
 type EndMetroVolumeOptions struct {
 	// DeleteRemoteVolume specifies whether or not to delete the remote volume when ending the metro session.
 	DeleteRemoteVolume bool `json:"delete_remote_volume,omitempty"`
 	// ForceDelete specifies if the Metro volume should be forcefully deleted.
+	// If the force option is specified, any errors returned while attempting to tear down the remote side of the
+	// metro session will be ignored and the remote side may be left in an indeterminate state.
+	// If any errors occur on the local side the operation can still fail.
+	// It is not recommended to use this option unless the remote side is known to be down.
+	ForceDelete bool `json:"force,omitempty"`
+}
+
+// EndMetroVolumeGroupOptions provides options for deleting the remote volume group and forcing the deletion.
+type EndMetroVolumeGroupOptions struct {
+	// DeleteRemoteVolumeGroup specifies whether or not to delete the remote volume group when ending the metro session.
+	DeleteRemoteVolumeGroup bool `json:"delete_remote_volume_group,omitempty"`
+	// ForceDelete specifies if the Metro volume group should be forcefully deleted.
 	// If the force option is specified, any errors returned while attempting to tear down the remote side of the
 	// metro session will be ignored and the remote side may be left in an indeterminate state.
 	// If any errors occur on the local side the operation can still fail.


### PR DESCRIPTION
# Description
Adding `metro_replication_session_id` to the `VolumeGroup` return type for use in csi-powerstore to determine whether a volume group is part of a metro replication session.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1443 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you maintained backward compatibility

## Testing
### Integration testing
Added new integration test to validate response data.
![image](https://github.com/user-attachments/assets/f315802a-fb2b-4a61-8b69-78ca010a7986)
