### PR TITLE
add metro-session-id field to VolumeGroup type

### DIFF
--- a/inttests/volume_group_test.go
+++ b/inttests/volume_group_test.go
@@ -220,6 +220,19 @@ func (s *MetroVolumeGroupTestSuite) TestConfigureMetroVolumeGroup() {
 	assert.NotEmpty(s.T(), resp)
 }
 
+// Make sure GetVolumeGroup returns the metro_replication_session_id
+func (s *MetroVolumeGroupTestSuite) TestGetMetroVGSessionFromVG() {
+	resp, err := s.client.ConfigureMetroVolumeGroup(context.Background(), s.vg.this.ID, &s.metro.config)
+	assert.NoError(s.T(), err)
+	assert.NotEmpty(s.T(), resp)
+
+	// Get the metro_replication_session_id from the Volume Group
+	vg, err := s.client.GetVolumeGroup(context.Background(), s.vg.this.ID)
+
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), resp.ID, vg.MetroReplicationSessionID)
+}
+
 // Try to configure metro on a volume group without any volumes in it.
 func (s *MetroVolumeGroupTestSuite) TestConfigMetroVGOnEmptyVG() {
 	// Delete all the volumes from the volume group.

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -86,6 +86,8 @@ type VolumeGroup struct {
 	LocationHistory []LocationHistory `json:"location_history,omitempty"`
 	//  This resource type has queriable associations from virtual_volume, volume, volume_group, replication_session
 	MigrationSession MigrationSession `json:"migration_session,omitempty"`
+	// Unique identifier of the replication session assigned to the volume group if it has been configured as a metro volume group between two PowerStore clusters.
+	MetroReplicationSessionID string `json:"metro_replication_session_id,omitempty"`
 }
 
 // Fields returns fields which must be requested to fill struct


### PR DESCRIPTION
# Description
Adding `metro_replication_session_id` to the `VolumeGroup` return type for use in csi-powerstore to determine whether a volume group is part of a metro replication session.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1443 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you maintained backward compatibility

## Testing
### Integration testing
Added new integration test to validate response data.
![image](https://github.com/user-attachments/assets/f315802a-fb2b-4a61-8b69-78ca010a7986)
