### PR TITLE
Replication observability metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ type Client interface {
 	PerformanceMetricsByAppliance(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByApplianceResponse, error)
 	PerformanceMetricsByNode(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByNodeResponse, error)
 	PerformanceMetricsByVolume(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVolumeResponse, error)
-	VolumeMirrorTransferRate(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]VolumeMirrorTransferRateResponse, error)
+	VolumeMirrorTransferRate(ctx context.Context, entityID string) ([]VolumeMirrorTransferRateResponse, error)
 	PerformanceMetricsByCluster(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByClusterResponse, error)
 	PerformanceMetricsByVM(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVMResponse, error)
 	PerformanceMetricsByVg(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVgResponse, error)

--- a/client.go
+++ b/client.go
@@ -142,6 +142,7 @@ type Client interface {
 	PerformanceMetricsByAppliance(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByApplianceResponse, error)
 	PerformanceMetricsByNode(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByNodeResponse, error)
 	PerformanceMetricsByVolume(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVolumeResponse, error)
+	VolumeMirrorTransferRate(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]VolumeMirrorTransferRateResponse, error)
 	PerformanceMetricsByCluster(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByClusterResponse, error)
 	PerformanceMetricsByVM(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVMResponse, error)
 	PerformanceMetricsByVg(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]PerformanceMetricsByVgResponse, error)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/dell/gopowerstore
 
 go 1.23
-
+toolchain go1.23.1
 require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/jarcoal/httpmock v1.2.0

--- a/inttests/metrics_test.go
+++ b/inttests/metrics_test.go
@@ -60,6 +60,19 @@ func Test_PerformanceMetricsByVolume(t *testing.T) {
 	assert.Equal(t, "performance_metrics_by_volume", resp[0].Entity)
 }
 
+func Test_VolumeMirrorTransferRate(t *testing.T) {
+	volumesResp, err := C.GetVolumes(context.Background())
+	checkAPIErr(t, err)
+	if len(volumesResp) == 0 {
+		t.Skip("no volumes are available to check for metrics")
+		return
+	}
+	resp, err := C.VolumeMirrorTransferRate(context.Background(), volumesResp[0].ID)
+	checkAPIErr(t, err)
+	assert.NotEmpty(t, resp)
+	assert.Equal(t, "volume_mirror_transfer_rate", resp[0].ID)
+}
+
 func Test_PerformanceMetricsByCluster(t *testing.T) {
 	resp, err := C.PerformanceMetricsByCluster(context.Background(), "0", gopowerstore.FiveMins)
 	checkAPIErr(t, err)

--- a/metrics.go
+++ b/metrics.go
@@ -25,8 +25,10 @@ import (
 	"net/http"
 )
 
-const metricsURL = "metrics"
-const mirrorURL = "volume_mirror_transfer_rate_cma_view"
+const (
+	metricsURL = "metrics"
+	mirrorURL  = "volume_mirror_transfer_rate_cma_view"
+)
 
 func (c *ClientIMPL) metricsRequest(ctx context.Context, response interface{}, entity string, entityID string, interval MetricsIntervalEnum) error {
 	_, err := c.APIClient().Query(
@@ -68,7 +70,6 @@ func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{
 			QueryParams: qp,
 		},
 		response)
-
 	if err != nil {
 		err = WrapErr(err)
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics.go
+++ b/metrics.go
@@ -49,11 +49,10 @@ func (c *ClientIMPL) metricsRequest(ctx context.Context, response interface{}, e
 }
 
 // mirrorTransferRate - Volume Mirror Transfer Rate
-func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{}, entityID string, limit int, interval MetricsIntervalEnum) error {
+func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{}, entityID string, limit int) error {
 	qp := getFSDefaultQueryParams(c)
 	qp.RawArg("id", fmt.Sprintf("eq.%s", entityID))
 	qp.Limit(limit)
-	//qp.RawArg("interval", string(interval))
 	qp.RawArg("select", "id,timestamp,synchronization_bandwidth,mirror_bandwidth,data_remaining")
 
 	customHeader := http.Header{}
@@ -99,9 +98,9 @@ func (c *ClientIMPL) PerformanceMetricsByVolume(ctx context.Context, entityID st
 }
 
 // VolumeMirrorTransferRate - Volume Mirror Transfer Rate
-func (c *ClientIMPL) VolumeMirrorTransferRate(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]VolumeMirrorTransferRateResponse, error) {
+func (c *ClientIMPL) VolumeMirrorTransferRate(ctx context.Context, entityID string) ([]VolumeMirrorTransferRateResponse, error) {
 	var resp []VolumeMirrorTransferRateResponse
-	err := c.mirrorTransferRate(ctx, &resp, entityID, 2000, interval)
+	err := c.mirrorTransferRate(ctx, &resp, entityID, 2000)
 	return resp, err
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -75,6 +75,7 @@ func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{
 		err = WrapErr(err)
 	}
 	customHeader.Del("DELL-VISIBILITY")
+	apiClient.SetCustomHTTPHeaders(customHeader)
 
 	return err
 }

--- a/metrics.go
+++ b/metrics.go
@@ -48,9 +48,10 @@ func (c *ClientIMPL) metricsRequest(ctx context.Context, response interface{}, e
 }
 
 // mirrorTransferRate - Volume Mirror Transfer Rate
-func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{}, entityID string, interval MetricsIntervalEnum) error {
+func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{}, entityID string, limit int, interval MetricsIntervalEnum) error {
 	qp := getFSDefaultQueryParams(c)
 	qp.RawArg("volume_id", fmt.Sprintf("eq.%s", entityID))
+	qp.RawArg("limit", fmt.Sprintf("%d", limit))
 	qp.RawArg("interval", string(interval))
 
 	_, err := c.APIClient().Query(
@@ -91,7 +92,7 @@ func (c *ClientIMPL) PerformanceMetricsByVolume(ctx context.Context, entityID st
 // VolumeMirrorTransferRate - Volume Mirror Transfer Rate
 func (c *ClientIMPL) VolumeMirrorTransferRate(ctx context.Context, entityID string, interval MetricsIntervalEnum) ([]VolumeMirrorTransferRateResponse, error) {
 	var resp []VolumeMirrorTransferRateResponse
-	err := c.mirrorTransferRate(ctx, &resp, entityID, interval)
+	err := c.mirrorTransferRate(ctx, &resp, entityID, 2000, interval)
 	return resp, err
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -28,6 +28,7 @@ import (
 const (
 	metricsURL = "metrics"
 	mirrorURL  = "volume_mirror_transfer_rate_cma_view"
+	limit      = 2000
 )
 
 func (c *ClientIMPL) metricsRequest(ctx context.Context, response interface{}, entity string, entityID string, interval MetricsIntervalEnum) error {
@@ -73,6 +74,7 @@ func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{
 	if err != nil {
 		err = WrapErr(err)
 	}
+	customHeader.Del("DELL-VISIBILITY")
 
 	return err
 }
@@ -101,7 +103,7 @@ func (c *ClientIMPL) PerformanceMetricsByVolume(ctx context.Context, entityID st
 // VolumeMirrorTransferRate - Volume Mirror Transfer Rate
 func (c *ClientIMPL) VolumeMirrorTransferRate(ctx context.Context, entityID string) ([]VolumeMirrorTransferRateResponse, error) {
 	var resp []VolumeMirrorTransferRateResponse
-	err := c.mirrorTransferRate(ctx, &resp, entityID, 2000)
+	err := c.mirrorTransferRate(ctx, &resp, entityID, limit)
 	return resp, err
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -30,6 +30,9 @@ import (
 )
 
 const metricsMockURL = APIMockURL + metricsURL
+const metricsMockVolMirrURL = APIMockURL + mirrorURL
+
+const volId = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 
 func TestClientIMPL_GetCapacity(t *testing.T) {
 	totalSpace0 := 12077448036352
@@ -134,6 +137,20 @@ func TestClientIMPL_PerformanceMetricsByVolume(t *testing.T) {
 	assert.Equal(t, "performance_metrics_by_volume", resp[0].Entity)
 	assert.Equal(t, "Volume-1", resp[0].VolumeID)
 	assert.Equal(t, float64(1000), resp[0].TotalIops)
+}
+
+func TestClientIMPL_VolumeMirrorTransferRate(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	setResponder := func(respData string) {
+		httpmock.RegisterResponder("GET", metricsMockVolMirrURL,
+			httpmock.NewStringResponder(200, respData))
+	}
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, volId)
+	setResponder(respData)
+	volMirr, err := C.VolumeMirrorTransferRate(context.Background(), volId)
+	assert.Nil(t, err)
+	assert.Equal(t, volId, volMirr[0].ID)
 }
 
 func TestClientIMPL_PerformanceMetricsByCluster(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -32,7 +32,7 @@ import (
 const metricsMockURL = APIMockURL + metricsURL
 const metricsMockVolMirrURL = APIMockURL + mirrorURL
 
-const volID = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
+const volumeID = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 
 func TestClientIMPL_GetCapacity(t *testing.T) {
 	totalSpace0 := 12077448036352
@@ -146,11 +146,11 @@ func TestClientIMPL_VolumeMirrorTransferRate(t *testing.T) {
 		httpmock.RegisterResponder("GET", metricsMockVolMirrURL,
 			httpmock.NewStringResponder(200, respData))
 	}
-	respData := fmt.Sprintf(`[{"id": "%s"}]`, volID)
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, volumeID)
 	setResponder(respData)
-	volMirr, err := C.VolumeMirrorTransferRate(context.Background(), volID)
+	volMirr, err := C.VolumeMirrorTransferRate(context.Background(), volumeID)
 	assert.Nil(t, err)
-	assert.Equal(t, volID, volMirr[0].ID)
+	assert.Equal(t, volumeID, volMirr[0].ID)
 }
 
 func TestClientIMPL_PerformanceMetricsByCluster(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,8 @@ import (
 const (
 	metricsMockURL        = APIMockURL + metricsURL
 	metricsMockVolMirrURL = APIMockURL + mirrorURL
+	volumeID              = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 )
-
-const volumeID = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 
 func TestClientIMPL_GetCapacity(t *testing.T) {
 	totalSpace0 := 12077448036352

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -29,12 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	metricsMockURL        = APIMockURL + metricsURL
-	metricsMockVolMirrURL = APIMockURL + mirrorURL
-)
+const metricsMockURL = APIMockURL + metricsURL
+const metricsMockVolMirrURL = APIMockURL + mirrorURL
 
-const volId = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
+const volID = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 
 func TestClientIMPL_GetCapacity(t *testing.T) {
 	totalSpace0 := 12077448036352
@@ -148,11 +146,11 @@ func TestClientIMPL_VolumeMirrorTransferRate(t *testing.T) {
 		httpmock.RegisterResponder("GET", metricsMockVolMirrURL,
 			httpmock.NewStringResponder(200, respData))
 	}
-	respData := fmt.Sprintf(`[{"id": "%s"}]`, volId)
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, volID)
 	setResponder(respData)
-	volMirr, err := C.VolumeMirrorTransferRate(context.Background(), volId)
+	volMirr, err := C.VolumeMirrorTransferRate(context.Background(), volID)
 	assert.Nil(t, err)
-	assert.Equal(t, volId, volMirr[0].ID)
+	assert.Equal(t, volID, volMirr[0].ID)
 }
 
 func TestClientIMPL_PerformanceMetricsByCluster(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -29,8 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const metricsMockURL = APIMockURL + metricsURL
-const metricsMockVolMirrURL = APIMockURL + mirrorURL
+const (
+	metricsMockURL        = APIMockURL + metricsURL
+	metricsMockVolMirrURL = APIMockURL + mirrorURL
+)
 
 const volumeID = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -29,8 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const metricsMockURL = APIMockURL + metricsURL
-const metricsMockVolMirrURL = APIMockURL + mirrorURL
+const (
+	metricsMockURL        = APIMockURL + metricsURL
+	metricsMockVolMirrURL = APIMockURL + mirrorURL
+)
 
 const volId = "4ffcd8e8-2a93-49ed-b9b3-2e68c8ddc5e4"
 

--- a/metrics_types.go
+++ b/metrics_types.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metrics_types.go
+++ b/metrics_types.go
@@ -1200,16 +1200,16 @@ type VolumeMirrorTransferRateResponse struct {
 	ID string `json:"id,omitempty"`
 
 	// The timestamp of the last read or write operation.
-	Timestamp int64 `json:"timestamp,omitempty"`
+	Timestamp strfmt.DateTime `json:"timestamp,omitempty"`
 
 	// The read or write bandwidth in bytes per second.
-	SynchronizationBandwidth int64 `json:"synchronization_bandwidth,omitempty"`
+	SynchronizationBandwidth float32 `json:"synchronization_bandwidth,omitempty"`
 
 	// The read or write bandwidth in bytes per second.
-	MirrorBandwidth int64 `json:"mirror_bandwidth,omitempty"`
+	MirrorBandwidth float32 `json:"mirror_bandwidth,omitempty"`
 
 	// The amount of data remaining in the bandwidth
-	DataRemaining int64 `json:"data_remaining,omitempty"`
+	DataRemaining float32 `json:"data_remaining,omitempty"`
 }
 
 type CommonAvgFields struct {

--- a/metrics_types.go
+++ b/metrics_types.go
@@ -1194,6 +1194,24 @@ type PerformanceMetricsByVolumeResponse struct {
 	CommonMaxAvgIopsBandwidthFields
 }
 
+// VolumeMirrorTransferRateResponse is returned by volume_mirror_transfer_rate
+type VolumeMirrorTransferRateResponse struct {
+	// Unique identifier representing a specific volume.
+	ID string `json:"id,omitempty"`
+
+	// The timestamp of the last read or write operation.
+	Timestamp int64 `json:"timestamp,omitempty"`
+
+	// The read or write bandwidth in bytes per second.
+	SynchronizationBandwidth int64 `json:"synchronization_bandwidth,omitempty"`
+
+	// The read or write bandwidth in bytes per second.
+	MirrorBandwidth int64 `json:"mirror_bandwidth,omitempty"`
+
+	// The amount of data remaining in the bandwidth
+	DataRemaining int64 `json:"data_remaining,omitempty"`
+}
+
 type CommonAvgFields struct {
 	// Average size of read and write operations in bytes.
 	AvgIoSize float32 `json:"avg_io_size,omitempty"`

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -3738,7 +3738,6 @@ func (_m *Client) VolumeMirrorTransferRate(ctx context.Context, entityID string)
 	return r0, r1
 }
 
-
 // PerformanceMetricsNfsByNode provides a mock function with given fields: ctx, entityID, interval
 func (_m *Client) PerformanceMetricsNfsByNode(ctx context.Context, entityID string, interval gopowerstore.MetricsIntervalEnum) ([]gopowerstore.PerformanceMetricsByNfsResponse, error) {
 	ret := _m.Called(ctx, entityID, interval)
@@ -4370,7 +4369,8 @@ func (_m *Client) WearMetricsByDrive(ctx context.Context, entityID string, inter
 func NewClient(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *Client {
+},
+) *Client {
 	mock := &Client{}
 	mock.Mock.Test(t)
 

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -3711,6 +3711,34 @@ func (_m *Client) PerformanceMetricsByVolume(ctx context.Context, entityID strin
 	return r0, r1
 }
 
+func (_m *Client) VolumeMirrorTransferRate(ctx context.Context, entityID string) ([]gopowerstore.VolumeMirrorTransferRateResponse, error) {
+	ret := _m.Called(ctx, entityID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for VolumeMirrorTransferRate")
+	}
+
+	var r0 []gopowerstore.VolumeMirrorTransferRateResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]gopowerstore.VolumeMirrorTransferRateResponse, error)); ok {
+		return rf(ctx, entityID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []gopowerstore.VolumeMirrorTransferRateResponse); ok {
+		r0 = rf(ctx, entityID)
+	} else {
+		r0 = ret.Get(0).([]gopowerstore.VolumeMirrorTransferRateResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, entityID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+
 // PerformanceMetricsNfsByNode provides a mock function with given fields: ctx, entityID, interval
 func (_m *Client) PerformanceMetricsNfsByNode(ctx context.Context, entityID string, interval gopowerstore.MetricsIntervalEnum) ([]gopowerstore.PerformanceMetricsByNfsResponse, error) {
 	ret := _m.Called(ctx, entityID, interval)


### PR DESCRIPTION
# PR Submission checklist
It enables API support for volume_mirror_transfer_rate_cma_view which will be helpful to pull the Replication related stats for Sync and Metro at volume level.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1443|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:

- Executed gopowerstore unit tests 

Earlier unit-test report
```
PASS
coverage: 82.2% of statements
ok      github.com/dell/gopowerstore    0.069s  coverage: 82.2% of statements
```

Current unit-test report
```
=== RUN   TestClientIMPL_VolumeMirrorTransferRate
--- PASS: TestClientIMPL_VolumeMirrorTransferRate (0.00s)

PASS
coverage: 83.8% of statements
ok      github.com/dell/gopowerstore    0.064s  coverage: 83.8% of statements
```
