### PR TITLE
order by time

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -28,7 +28,7 @@ import (
 const (
 	metricsURL = "metrics"
 	mirrorURL  = "volume_mirror_transfer_rate_cma_view"
-	limit      = 2000
+	limit      = 1
 )
 
 func (c *ClientIMPL) metricsRequest(ctx context.Context, response interface{}, entity string, entityID string, interval MetricsIntervalEnum) error {
@@ -56,6 +56,7 @@ func (c *ClientIMPL) mirrorTransferRate(ctx context.Context, response interface{
 	qp := getFSDefaultQueryParams(c)
 	qp.RawArg("id", fmt.Sprintf("eq.%s", entityID))
 	qp.Limit(limit)
+	qp.RawArg("order", "timestamp.desc")
 	qp.RawArg("select", "id,timestamp,synchronization_bandwidth,mirror_bandwidth,data_remaining")
 
 	customHeader := http.Header{}


### PR DESCRIPTION
# PR Submission checklist
Set order by timestamp and fetch the latest record only.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1443|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
After updating the select query parameter using order by time stamp and limit as 1, it fetches the latest record and is consistent across other params being fetched.

`time="2024-10-11T11:33:15Z" level=debug msg="persistent volume is not nfs" persistent_volume=csivol-86b3213c6b protocol=scsi
time="2024-10-11T11:33:22Z" level=debug msg="volume metrics" mirror_bandwidth=711.6486 read_bandwidth=0 read_iops=0 read_latency=0 remaining_data=0 syncronization_bandwidth=0 volume_meta="&{c2d584c3-b4f1-41d7-8ac7-14fa14ca6e5c csivol-86b3213c6b pvol-metro-136 default PS30ddf4e1d754 }" write_bandwidth=711.6486 write_iops=712.6 write_latency=5.496929
`
