### PR TITLE
Update fs_types.go to revert size - omitempty

### DIFF
--- a/fs_types.go
+++ b/fs_types.go
@@ -102,7 +102,7 @@ type FSModify struct {
 	//maximum: 281474976710656
 	//
 	//Size, in bytes, presented to the host or end user. This can be used for both expand and shrink on a file system.
-	Size                       int           `json:"size_total"`
+	Size                       int           `json:"size_total,omitempty"`
 	Description                string        `json:"description,omitempty"`
 	AccessPolicy               string        `json:"access_policy,omitempty"`
 	LockingPolicy              string        `json:"locking_policy,omitempty"`


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:
Need to revert back the size definition to 'omitempty'.

| GitHub Issue # |
| -------------- |
| |

# Common PR Checklist:

- [ ] Have you made sure that the code compiles?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Have you maintained backward compatibility

## Description of your changes:
<your change goes here>
