### PR TITLE
NFS Export new fields added

### DIFF
--- a/inttests/replication_sync_test.go
+++ b/inttests/replication_sync_test.go
@@ -128,12 +128,13 @@ func (suite *ReplicationTestSuiteSync) TestReplicationSync() {
 	assert.NoError(t, err)
 	assert.Equal(t, rs.ID, remoteSystem)
 
+	isWriteOrderConsistent := true
 	// create a volume group with a protection policy
 	// A protection policy with a synchronous replication rule can only be applied to a write-order consistent volume group
 	suite.vg, err = C.CreateVolumeGroup(context.Background(), &gopowerstore.VolumeGroupCreate{
 		Name:                   "intcsi" + suite.randomString + "-vgtst",
 		ProtectionPolicyID:     suite.pp.ID,
-		IsWriteOrderConsistent: true,
+		IsWriteOrderConsistent: &isWriteOrderConsistent,
 	})
 	assert.NoError(t, err)
 

--- a/inttests/volume_group_test.go
+++ b/inttests/volume_group_test.go
@@ -149,11 +149,12 @@ func (s *MetroVolumeGroupTestSuite) SetupTest() {
 	// Create a unique vg name for each test run.
 	s.vg.this.Name = VGPrefix + randString(8)
 
+	isWriteOrderConsistent := true
 	// Create a volume group to run tests against.
 	resp, err := s.client.CreateVolumeGroup(context.Background(), &g.VolumeGroupCreate{
 		Name:                   s.vg.this.Name,
 		VolumeIDs:              s.vg.volumeIDs,
-		IsWriteOrderConsistent: true,
+		IsWriteOrderConsistent: &isWriteOrderConsistent,
 	})
 	assert.NoError(s.T(), err)
 
@@ -318,11 +319,12 @@ func (s *EndMetroVolumeGroupTestSuite) SetupTest() {
 	// Create a unique vg name for each test run.
 	s.vg.this.Name = VGPrefix + randString(8)
 
+	isWriteOrderConsistent := true
 	// Create a volume group to run tests against.
 	resp, err := s.client.CreateVolumeGroup(context.Background(), &g.VolumeGroupCreate{
 		Name:                   s.vg.this.Name,
 		VolumeIDs:              s.vg.volumeIDs,
-		IsWriteOrderConsistent: true,
+		IsWriteOrderConsistent: &isWriteOrderConsistent,
 	})
 	assert.NoError(s.T(), err)
 

--- a/nfs_types.go
+++ b/nfs_types.go
@@ -38,6 +38,28 @@ type NFSExportCreate struct {
 	FileSystemID string `json:"file_system_id"`
 	// Local path to a location within the file system.
 	Path string `json:"path"`
+	// Default access level for all hosts that can access the Export
+	DefaultAccess NFSExportDefaultAccessEnum `json:"default_access,omitempty"`
+	// NFS enforced security type for users accessing an NFS Export.
+	MinSecurity string `json:"min_security,omitempty"`
+	// Hosts with no access to the NFS export or its snapshots.
+	NoAccessHosts []string `json:"no_access_hosts,omitempty"`
+	// Hosts with read-only access to the NFS export and its snapshots.
+	ReadOnlyHosts []string `json:"read_only_hosts,omitempty"`
+	// Hosts with read-only and ready-only for root user access to the NFS Export and its snapshots.
+	ReadOnlyRootHosts []string `json:"read_only_root_hosts,omitempty"`
+	// Hosts with read and write access to the NFS export and its snapshots.
+	ReadWriteHosts []string `json:"read_write_hosts,omitempty"`
+	// Hosts with read and write and read and write for root user access to the NFS Export and its snapshots.
+	ReadWriteRootHosts []string `json:"read_write_root_hosts,omitempty"`
+	// Specifies the user ID of the anonymous account.
+	AnonymousUID int32 `json:"anonymous_UID,omitempty"`
+	// Specifies the group ID of the anonymous account.
+	AnonymousGID int32 `json:"anonymous_GID,omitempty"`
+	// If set, do not allow access to set SUID. Otherwise, allow access.
+	IsNoSUID bool `json:"is_no_SUID"`
+	// (*Applies to NFS shares of VMware NFS storage resources.*) Default owner of the NFS Export associated with the datastore. Required if secure NFS enabled. For NFSv3 or NFSv4 without Kerberos, the default owner is root. Was added in version 3.0.0.0.
+	NFSOwnerUsername string `json:"nfs_owner_username,omitempty"`
 }
 
 // NFSExportModify details about modification of exiting NFS export
@@ -75,6 +97,29 @@ type NFSExportModify struct {
 	AddNoAccessHosts []string `json:"add_no_access_hosts,omitempty"`
 	// Hosts to remove from the current no_access_hosts list. Hosts can be entered by Hostname, IP addresses
 	RemoveNoAccessHosts []string `json:"remove_no_access_hosts,omitempty"`
+
+	// Default access level for all hosts that can access the Export.
+	DefaultAccess string `json:"default_access,omitempty"`
+	// NFS enforced security type for users accessing an NFS Export.
+	MinSecurity string `json:"min_security,omitempty"`
+	// Hosts with no access to the NFS export or its snapshots.
+	NoAccessHosts []string `json:"no_access_hosts,omitempty"`
+	// Hosts with read-only access to the NFS export and its snapshots.
+	ReadOnlyHosts []string `json:"read_only_hosts,omitempty"`
+	// Hosts with read-only and ready-only for root user access to the NFS Export and its snapshots.
+	ReadOnlyRootHosts []string `json:"read_only_root_hosts,omitempty"`
+	// Hosts with read and write access to the NFS export and its snapshots.
+	ReadWriteHosts []string `json:"read_write_hosts,omitempty"`
+	// Hosts with read and write and read and write for root user access to the NFS Export and its snapshots.
+	ReadWriteRootHosts []string `json:"read_write_root_hosts,omitempty"`
+	// Specifies the user ID of the anonymous account.
+	AnonymousUID int32 `json:"anonymous_UID,omitempty"`
+	// Specifies the group ID of the anonymous account.
+	AnonymousGID int32 `json:"anonymous_GID,omitempty"`
+	// If set, do not allow access to set SUID. Otherwise, allow access.
+	IsNoSUID bool `json:"is_no_SUID"`
+	// (*Applies to NFS shares of VMware NFS storage resources.*) Default owner of the NFS Export associated with the datastore. Required if secure NFS enabled. For NFSv3 or NFSv4 without Kerberos, the default owner is root. Was added in version 3.0.0.0.
+	NFSOwnerUsername string `json:"nfs_owner_usernamestring,omitempty"`
 }
 
 // NFSServerCreate details about creation of new NFS server
@@ -116,6 +161,21 @@ type NFSExport struct {
 	RWRootHosts []string `json:"read_write_root_hosts,omitempty"`
 	// Read-Only, allow Roots hosts
 	RORootHosts []string `json:"read_only_root_hosts,omitempty"`
+	// NFS enforced security type for users accessing an NFS Export.
+	// [ Sys, Kerberos, Kerberos_With_Integrity, Kerberos_With_Encryption ]
+	MinSecurity string `json:"min_security,omitempty"`
+	// (*Applies to NFS shares of VMware NFS storage resources.*)
+	// Default owner of the NFS Export associated with the datastore.
+	// Required if secure NFS enabled.
+	NFSOwnerUsername string `json:"nfs_owner_username,omitempty"`
+	// Hosts with no access to the NFS export or its snapshots.
+	NoAccessHosts []string `json:"no_access_hosts,omitempty"`
+	// Specifies the user ID of the anonymous account.
+	AnonymousUID int32 `json:"anonymous_UID,omitempty"`
+	// Specifies the group ID of the anonymous account.
+	AnonymousGID int32 `json:"anonymous_GID,omitempty"`
+	// If set, do not allow access to set SUID. Otherwise, allow access.
+	IsNoSUID bool `json:"is_no_SUID"`
 }
 
 // Details about the file interface
@@ -128,7 +188,8 @@ type FileInterface struct {
 
 // Fields returns fields which must be requested to fill struct
 func (n *NFSExport) Fields() []string {
-	return []string{"description", "id", "name", "file_system_id", "default_access", "path", "read_only_hosts", "read_only_root_hosts", "read_write_hosts", "read_write_root_hosts"}
+	return []string{"description", "id", "name", "file_system_id", "default_access", "path", "read_only_hosts", "read_only_root_hosts", "read_write_hosts", "read_write_root_hosts",
+		"min_security", "nfs_owner_username", "no_access_hosts", "anonymous_UID", "anonymous_GID", "is_no_SUID"}
 }
 
 // Fields returns fields which must be requested to fill struct

--- a/nfs_types.go
+++ b/nfs_types.go
@@ -46,7 +46,7 @@ type NFSExportCreate struct {
 	NoAccessHosts []string `json:"no_access_hosts,omitempty"`
 	// Hosts with read-only access to the NFS export and its snapshots.
 	ReadOnlyHosts []string `json:"read_only_hosts,omitempty"`
-	// Hosts with read-only and ready-only for root user access to the NFS Export and its snapshots.
+	// Hosts with read-only and read-only for root user access to the NFS Export and its snapshots.
 	ReadOnlyRootHosts []string `json:"read_only_root_hosts,omitempty"`
 	// Hosts with read and write access to the NFS export and its snapshots.
 	ReadWriteHosts []string `json:"read_write_hosts,omitempty"`
@@ -106,7 +106,7 @@ type NFSExportModify struct {
 	NoAccessHosts []string `json:"no_access_hosts,omitempty"`
 	// Hosts with read-only access to the NFS export and its snapshots.
 	ReadOnlyHosts []string `json:"read_only_hosts,omitempty"`
-	// Hosts with read-only and ready-only for root user access to the NFS Export and its snapshots.
+	// Hosts with read-only and read-only for root user access to the NFS Export and its snapshots.
 	ReadOnlyRootHosts []string `json:"read_only_root_hosts,omitempty"`
 	// Hosts with read and write access to the NFS export and its snapshots.
 	ReadWriteHosts []string `json:"read_write_hosts,omitempty"`

--- a/nfs_types.go
+++ b/nfs_types.go
@@ -188,8 +188,7 @@ type FileInterface struct {
 
 // Fields returns fields which must be requested to fill struct
 func (n *NFSExport) Fields() []string {
-	return []string{"description", "id", "name", "file_system_id", "default_access", "path", "read_only_hosts", "read_only_root_hosts", "read_write_hosts", "read_write_root_hosts",
-		"min_security", "nfs_owner_username", "no_access_hosts", "anonymous_UID", "anonymous_GID", "is_no_SUID"}
+	return []string{"description", "id", "name", "file_system_id", "default_access", "path", "read_only_hosts", "read_only_root_hosts", "read_write_hosts", "read_write_root_hosts", "min_security", "nfs_owner_username", "no_access_hosts", "anonymous_UID", "anonymous_GID", "is_no_SUID"}
 }
 
 // Fields returns fields which must be requested to fill struct

--- a/volume_group_test.go
+++ b/volume_group_test.go
@@ -208,10 +208,12 @@ func TestClientIMPL_ModifyVolumeGroupSnapshot(t *testing.T) {
 	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/%s", volumeGroupMockURL, volID),
 		httpmock.NewStringResponder(201, respData))
 
+	IsWriteOrderConsistent := false
+
 	modifyParams := VolumeGroupSnapshotModify{
 		Description:            "test description",
 		Name:                   "test name",
-		IsWriteOrderConsistent: false,
+		IsWriteOrderConsistent: &IsWriteOrderConsistent,
 	}
 
 	resp, err := C.ModifyVolumeGroupSnapshot(context.Background(), &modifyParams, volID)

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -40,7 +40,7 @@ type VolumeGroupCreate struct {
 	ProtectionPolicyID string `json:"protection_policy_id,omitempty"`
 	// For a primary or a clone volume group, this property determines whether snapshot sets of the group will be write order consistent.
 	// If not specified, this parameter defaults to true in PowerStore API.
-	IsWriteOrderConsistent bool `json:"is_write_order_consistent,omitempty"`
+	IsWriteOrderConsistent *bool `json:"is_write_order_consistent,omitempty"`
 	// A list of identifiers of existing volumes that should be added to the volume group.
 	// All the volumes must be on the same Cyclone appliance and should not be part of another volume group.
 	// If a list of volumes is not specified or if the specified list is empty, an
@@ -109,7 +109,7 @@ type VolumeGroupModify struct {
 	ProtectionPolicyID     string  `json:"protection_policy_id"` // empty to unassign
 	Description            string  `json:"description"`
 	Name                   string  `json:"name,omitempty"`
-	IsWriteOrderConsistent bool    `json:"is_write_order_consistent,omitempty"`
+	IsWriteOrderConsistent *bool    `json:"is_write_order_consistent,omitempty"`
 	ExpirationTimestamp    *string `json:"expiration_timestamp,omitempty"`
 }
 
@@ -117,7 +117,7 @@ type VolumeGroupModify struct {
 type VolumeGroupSnapshotModify struct {
 	Description            string  `json:"description"`
 	Name                   string  `json:"name,omitempty"`
-	IsWriteOrderConsistent bool    `json:"is_write_order_consistent,omitempty"`
+	IsWriteOrderConsistent *bool    `json:"is_write_order_consistent,omitempty"`
 	ExpirationTimestamp    *string `json:"expiration_timestamp,omitempty"`
 }
 

--- a/volume_group_types.go
+++ b/volume_group_types.go
@@ -109,7 +109,7 @@ type VolumeGroupModify struct {
 	ProtectionPolicyID     string  `json:"protection_policy_id"` // empty to unassign
 	Description            string  `json:"description"`
 	Name                   string  `json:"name,omitempty"`
-	IsWriteOrderConsistent *bool    `json:"is_write_order_consistent,omitempty"`
+	IsWriteOrderConsistent *bool   `json:"is_write_order_consistent,omitempty"`
 	ExpirationTimestamp    *string `json:"expiration_timestamp,omitempty"`
 }
 
@@ -117,7 +117,7 @@ type VolumeGroupModify struct {
 type VolumeGroupSnapshotModify struct {
 	Description            string  `json:"description"`
 	Name                   string  `json:"name,omitempty"`
-	IsWriteOrderConsistent *bool    `json:"is_write_order_consistent,omitempty"`
+	IsWriteOrderConsistent *bool   `json:"is_write_order_consistent,omitempty"`
 	ExpirationTimestamp    *string `json:"expiration_timestamp,omitempty"`
 }
 


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/terraform-provider-powerstore/pull/124|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
A new NFS export resource will be added on terraform-provider-powerstore so added new fields for the same
updated bool to *bool, for is_write_order_consistent attribute in volume group, since it was not working with false value of the bool field


![image](https://github.com/user-attachments/assets/6f3c0190-a646-43cc-9305-6240350d804c)
