### PR TITLE
SMB Share CRUD Operations

### DIFF
--- a/client.go
+++ b/client.go
@@ -200,6 +200,9 @@ type Client interface {
 	ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
 	EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error)
+	CreateSMBShare(ctx context.Context, createParams *SMBShareCreate) (resp CreateResponse, err error)
+	ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error)
+	DeleteSMBShare(ctx context.Context, id string) (resp EmptyResponse, err error)
 	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
 	GetSMBShares(ctx context.Context, filter *string) ([]SMBShare, error)
 }

--- a/client.go
+++ b/client.go
@@ -201,6 +201,7 @@ type Client interface {
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
 	EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error)
 	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
+	GetSMBShares(ctx context.Context, filter *string) ([]SMBShare, error)
 }
 
 // ClientIMPL provides basic API client implementation

--- a/client.go
+++ b/client.go
@@ -201,7 +201,7 @@ type Client interface {
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
 	EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error)
 	CreateSMBShare(ctx context.Context, createParams *SMBShareCreate) (resp CreateResponse, err error)
-	ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error)
+	ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareModify) (resp EmptyResponse, err error)
 	DeleteSMBShare(ctx context.Context, id string) (resp EmptyResponse, err error)
 	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
 	GetSMBShares(ctx context.Context, filter *string) ([]SMBShare, error)

--- a/client.go
+++ b/client.go
@@ -200,6 +200,7 @@ type Client interface {
 	ConfigureMetroVolumeGroup(ctx context.Context, id string, config *MetroConfig) (resp MetroSessionResponse, err error)
 	EndMetroVolume(ctx context.Context, id string, options *EndMetroVolumeOptions) (resp EmptyResponse, err error)
 	EndMetroVolumeGroup(ctx context.Context, id string, options *EndMetroVolumeGroupOptions) (resp EmptyResponse, err error)
+	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
 }
 
 // ClientIMPL provides basic API client implementation

--- a/client.go
+++ b/client.go
@@ -204,8 +204,8 @@ type Client interface {
 	ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareModify) (resp EmptyResponse, err error)
 	DeleteSMBShare(ctx context.Context, id string) (resp EmptyResponse, err error)
 	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
-	SetSMBShareAcl(ctx context.Context, id string, acl *ModifySMBShareAcl) (resp EmptyResponse, err error)
-	GetSMBShareAcl(ctx context.Context, id string) (resp SMBShareAcl, err error)
+	SetSMBShareACL(ctx context.Context, id string, acl *ModifySMBShareACL) (resp EmptyResponse, err error)
+	GetSMBShareACL(ctx context.Context, id string) (resp SMBShareACL, err error)
 }
 
 // ClientIMPL provides basic API client implementation

--- a/client.go
+++ b/client.go
@@ -204,7 +204,8 @@ type Client interface {
 	ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareModify) (resp EmptyResponse, err error)
 	DeleteSMBShare(ctx context.Context, id string) (resp EmptyResponse, err error)
 	GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error)
-	GetSMBShares(ctx context.Context, filter *string) ([]SMBShare, error)
+	SetSMBShareAcl(ctx context.Context, id string, acl *ModifySMBShareAcl) (resp EmptyResponse, err error)
+	GetSMBShareAcl(ctx context.Context, id string) (resp SMBShareAcl, err error)
 }
 
 // ClientIMPL provides basic API client implementation

--- a/smb_share.go
+++ b/smb_share.go
@@ -41,7 +41,7 @@ func (c *ClientIMPL) CreateSMBShare(ctx context.Context, createParams *SMBShareC
 	return resp, WrapErr(err)
 }
 
-// ModifySMBShare modifies new SMB share
+// ModifySMBShare modifies SMB share
 func (c *ClientIMPL) ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,

--- a/smb_share.go
+++ b/smb_share.go
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gopowerstore
+
+import "context"
+
+const (
+	smbShareURL = "smb_share"
+)
+
+// GetSMBShare returns specific smb share by id
+func (c *ClientIMPL) GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error) {
+	share := SMBShare{}
+	qp := c.APIClient().QueryParamsWithFields(&share)
+
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:      "GET",
+			Endpoint:    smbShareURL,
+			ID:          id,
+			QueryParams: qp,
+		},
+		&resp)
+	return resp, WrapErr(err)
+}

--- a/smb_share.go
+++ b/smb_share.go
@@ -41,8 +41,8 @@ func (c *ClientIMPL) CreateSMBShare(ctx context.Context, createParams *SMBShareC
 	return resp, WrapErr(err)
 }
 
-// MpdifySMBShare modifies new SMB share
-func (c *ClientIMPL) MpdifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error) {
+// ModifySMBShare modifies new SMB share
+func (c *ClientIMPL) ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{

--- a/smb_share.go
+++ b/smb_share.go
@@ -24,8 +24,8 @@ import (
 
 const (
 	smbShareURL       = "smb_share"
-	smbShareGetAclURL = "/get_acl"
-	smbShareSetAclURL = "/set_acl"
+	smbShareGetACLURL = "/get_acl"
+	smbShareSetACLURL = "/set_acl"
 )
 
 // CreateSMBShare creates new SMB share
@@ -85,25 +85,25 @@ func (c *ClientIMPL) GetSMBShare(ctx context.Context, id string) (resp SMBShare,
 	return resp, WrapErr(err)
 }
 
-// GetSMBShareAcl returns specific smb share ACL by id
-func (c *ClientIMPL) GetSMBShareAcl(ctx context.Context, id string) (resp SMBShareAcl, err error) {
+// GetSMBShareACL returns specific smb share ACL by id
+func (c *ClientIMPL) GetSMBShareACL(ctx context.Context, id string) (resp SMBShareACL, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
 			Method:   "POST",
-			Endpoint: smbShareURL + "/" + id + smbShareGetAclURL,
+			Endpoint: smbShareURL + "/" + id + smbShareGetACLURL,
 		},
 		&resp)
 	return resp, WrapErr(err)
 }
 
-// SetSMBShareAcl modifies specific smb share ACL by id
-func (c *ClientIMPL) SetSMBShareAcl(ctx context.Context, id string, aclParams *ModifySMBShareAcl) (resp EmptyResponse, err error) {
+// SetSMBShareACL modifies specific smb share ACL by id
+func (c *ClientIMPL) SetSMBShareACL(ctx context.Context, id string, aclParams *ModifySMBShareACL) (resp EmptyResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
 			Method:   "POST",
-			Endpoint: smbShareURL + "/" + id + smbShareSetAclURL,
+			Endpoint: smbShareURL + "/" + id + smbShareSetACLURL,
 			Body:     aclParams,
 		},
 		&resp)

--- a/smb_share.go
+++ b/smb_share.go
@@ -42,7 +42,7 @@ func (c *ClientIMPL) CreateSMBShare(ctx context.Context, createParams *SMBShareC
 }
 
 // ModifySMBShare modifies SMB share
-func (c *ClientIMPL) ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error) {
+func (c *ClientIMPL) ModifySMBShare(ctx context.Context, id string, modifyParams *SMBShareModify) (resp EmptyResponse, err error) {
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{

--- a/smb_share.go
+++ b/smb_share.go
@@ -48,6 +48,7 @@ func (c *ClientIMPL) ModifySMBShare(ctx context.Context, id string, modifyParams
 		RequestConfig{
 			Method:   "PATCH",
 			Endpoint: smbShareURL,
+			ID:       id,
 			Body:     modifyParams,
 		},
 		&resp)

--- a/smb_share.go
+++ b/smb_share.go
@@ -28,6 +28,45 @@ const (
 	smbShareURL = "smb_share"
 )
 
+// CreateSMBShare creates new SMB share
+func (c *ClientIMPL) CreateSMBShare(ctx context.Context, createParams *SMBShareCreate) (resp CreateResponse, err error) {
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:   "POST",
+			Endpoint: smbShareURL,
+			Body:     createParams,
+		},
+		&resp)
+	return resp, WrapErr(err)
+}
+
+// MpdifySMBShare modifies new SMB share
+func (c *ClientIMPL) MpdifySMBShare(ctx context.Context, id string, modifyParams *SMBShareCreate) (resp EmptyResponse, err error) {
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:   "PATCH",
+			Endpoint: smbShareURL,
+			Body:     modifyParams,
+		},
+		&resp)
+	return resp, WrapErr(err)
+}
+
+// DeleteSMBShare deletes existing SMB share
+func (c *ClientIMPL) DeleteSMBShare(ctx context.Context, id string) (resp EmptyResponse, err error) {
+	_, err = c.APIClient().Query(
+		ctx,
+		RequestConfig{
+			Method:   "DELETE",
+			Endpoint: smbShareURL,
+			ID:       id,
+		},
+		&resp)
+	return resp, WrapErr(err)
+}
+
 // GetSMBShare returns specific smb share by id
 func (c *ClientIMPL) GetSMBShare(ctx context.Context, id string) (resp SMBShare, err error) {
 	share := SMBShare{}

--- a/smb_share_test.go
+++ b/smb_share_test.go
@@ -28,8 +28,8 @@ import (
 const (
 	smbShareID            = "6732e829-29c9-7fed-686a-ee23cab1d298"
 	smbShareMockURL       = APIMockURL + smbShareURL
-	smbShareSetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareSetAclURL
-	smbShareGetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareGetAclURL
+	smbShareSetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareSetACLURL
+	smbShareGetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareGetACLURL
 )
 
 func TestClientIMPL_CreateSMBShare(t *testing.T) {
@@ -94,7 +94,7 @@ func TestClientIMPL_SetSMBShareAcl(t *testing.T) {
 	httpmock.RegisterResponder("POST", smbShareSetACLMockURL,
 		httpmock.NewStringResponder(204, ""))
 
-	createReq := &ModifySMBShareAcl{
+	createReq := &ModifySMBShareACL{
 		AddAces: []SMBShareAce{
 			{
 				TrusteeType: "WellKnown",
@@ -105,12 +105,12 @@ func TestClientIMPL_SetSMBShareAcl(t *testing.T) {
 		},
 	}
 
-	resp, err := C.SetSMBShareAcl(context.Background(), smbShareID, createReq)
+	resp, err := C.SetSMBShareACL(context.Background(), smbShareID, createReq)
 	assert.Nil(t, err)
 	assert.Equal(t, EmptyResponse(""), resp)
 }
 
-func TestClientIMPL_GetSMBShareAcl(t *testing.T) {
+func TestClientIMPL_GetSMBShareACL(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -119,7 +119,7 @@ func TestClientIMPL_GetSMBShareAcl(t *testing.T) {
 	httpmock.RegisterResponder("POST", smbShareGetACLMockURL,
 		httpmock.NewStringResponder(200, respData))
 
-	resp, err := C.GetSMBShareAcl(context.Background(), smbShareID)
+	resp, err := C.GetSMBShareACL(context.Background(), smbShareID)
 	assert.Nil(t, err)
 	assert.NotNil(t, resp.Aces)
 	assert.NotEqual(t, len(resp.Aces), 0)

--- a/smb_share_test.go
+++ b/smb_share_test.go
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gopowerstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	smbShareID            = "6732e829-29c9-7fed-686a-ee23cab1d298"
+	smbShareMockURL       = APIMockURL + smbShareURL
+	smbShareSetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareSetAclURL
+	smbShareGetACLMockURL = APIMockURL + smbShareURL + "/" + smbShareID + smbShareGetAclURL
+)
+
+func TestClientIMPL_CreateSMBShare(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	respData := fmt.Sprintf(`{"id": "%s"}`, smbShareID)
+	httpmock.RegisterResponder("POST", smbShareMockURL,
+		httpmock.NewStringResponder(201, respData))
+
+	createReq := SMBShareCreate{
+		FileSystemID: "6721f37d-8eda-7508-664c-ee23cab1d298",
+		Name:         "test_smb_share",
+		Path:         "XX-0000X",
+	}
+
+	resp, err := C.CreateSMBShare(context.Background(), &createReq)
+	assert.Nil(t, err)
+	assert.Equal(t, smbShareID, resp.ID)
+}
+
+func TestClientIMPL_ModifySMBShare(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/%s", smbShareMockURL, smbShareID),
+		httpmock.NewStringResponder(204, ""))
+
+	modifyParams := SMBShareModify{
+		Description:                     "modify smb share",
+		IsContinuousAvailabilityEnabled: true,
+	}
+
+	resp, err := C.ModifySMBShare(context.Background(), smbShareID, &modifyParams)
+	assert.Nil(t, err)
+	assert.Equal(t, EmptyResponse(""), resp)
+}
+
+func TestClientIMPL_DeleteSMBShare(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("DELETE", fmt.Sprintf("%s/%s", smbShareMockURL, smbShareID),
+		httpmock.NewStringResponder(204, ""))
+
+	resp, err := C.DeleteSMBShare(context.Background(), smbShareID)
+	assert.Nil(t, err)
+	assert.Len(t, string(resp), 0)
+}
+
+func TestClientIMPL_GetSMBShare(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	respData := fmt.Sprintf(`{"id": "%s"}`, smbShareID)
+	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/%s", smbShareMockURL, smbShareID),
+		httpmock.NewStringResponder(200, respData))
+	smbShare, err := C.GetSMBShare(context.Background(), smbShareID)
+	assert.Nil(t, err)
+	assert.Equal(t, smbShareID, smbShare.ID)
+}
+
+func TestClientIMPL_SetSMBShareAcl(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("POST", smbShareSetACLMockURL,
+		httpmock.NewStringResponder(204, ""))
+
+	createReq := &ModifySMBShareAcl{
+		AddAces: []SMBShareAce{
+			{
+				TrusteeType: "WellKnown",
+				TrusteeName: "Everyone",
+				AccessLevel: "Full",
+				AccessType:  "Allow",
+			},
+		},
+	}
+
+	resp, err := C.SetSMBShareAcl(context.Background(), smbShareID, createReq)
+	assert.Nil(t, err)
+	assert.Equal(t, EmptyResponse(""), resp)
+}
+
+func TestClientIMPL_GetSMBShareAcl(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	respData := `{"aces": [{"trustee_type": "WellKnown", "trustee_name": "Everyone", "access_level": "Full", "access_type": "Allow"}]}`
+
+	httpmock.RegisterResponder("POST", smbShareGetACLMockURL,
+		httpmock.NewStringResponder(200, respData))
+
+	resp, err := C.GetSMBShareAcl(context.Background(), smbShareID)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp.Aces)
+	assert.NotEqual(t, len(resp.Aces), 0)
+}

--- a/smb_share_test.go
+++ b/smb_share_test.go
@@ -56,9 +56,11 @@ func TestClientIMPL_ModifySMBShare(t *testing.T) {
 	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/%s", smbShareMockURL, smbShareID),
 		httpmock.NewStringResponder(204, ""))
 
+	desc := "modify smb share"
+	flag := true
 	modifyParams := SMBShareModify{
-		Description:                     "modify smb share",
-		IsContinuousAvailabilityEnabled: true,
+		Description:                     &desc,
+		IsContinuousAvailabilityEnabled: &flag,
 	}
 
 	resp, err := C.ModifySMBShare(context.Background(), smbShareID, &modifyParams)

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -71,14 +71,14 @@ type SMBShareAce struct {
 	AccessType  string `json:"access_type"`
 }
 
-// ModifySMBAcl defines struct for modifying SMB ACL
-type ModifySMBShareAcl struct {
+// ModifySMBShareACL defines struct for modifying SMB ACL
+type ModifySMBShareACL struct {
 	Aces       []SMBShareAce `json:"aces,omitempty"`
 	AddAces    []SMBShareAce `json:"add_aces,omitempty"`
 	RemoveAces []SMBShareAce `json:"remove_aces,omitempty"`
 }
 
-// SMBShareAcl defines struct for SMB ACL
-type SMBShareAcl struct {
+// SMBShareACL  defines struct for SMB ACL
+type SMBShareACL struct {
 	Aces []SMBShareAce `json:"aces"`
 }

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -18,6 +18,20 @@
 
 package gopowerstore
 
+// SMBShareCreate defines struct for creating SMB share
+type SMBShareCreate struct {
+	FileSystemID                    string `json:"file_system_id"`
+	Name                            string `json:"name"`
+	Path                            string `json:"path"`
+	Description                     string `json:"description,omitempty"`
+	IsContinuousAvailabilityEnabled bool   `json:"is_continuous_availability_enabled,omitempty"`
+	IsEncryptionEnabled             bool   `json:"is_encryption_enabled,omitempty"`
+	IsABEEnabled                    bool   `json:"is_ABE_enabled,omitempty"`
+	IsBranchCacheEnabled            bool   `json:"is_branch_cache_enabled,omitempty"`
+	OfflineAvailability             string `json:"offline_availability,omitempty"`
+	Umask                           string `json:"umask,omitempty"`
+}
+
 // SMBShare details about a SMB Share
 type SMBShare struct {
 	ID                              string `json:"id"`

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -34,13 +34,13 @@ type SMBShareCreate struct {
 
 // SMBShareModify defines struct for modifying SMB share
 type SMBShareModify struct {
-	Description                     string `json:"description,omitempty"`
-	IsContinuousAvailabilityEnabled bool   `json:"is_continuous_availability_enabled,omitempty"`
-	IsEncryptionEnabled             bool   `json:"is_encryption_enabled,omitempty"`
-	IsABEEnabled                    bool   `json:"is_ABE_enabled,omitempty"`
-	IsBranchCacheEnabled            bool   `json:"is_branch_cache_enabled,omitempty"`
-	OfflineAvailability             string `json:"offline_availability,omitempty"`
-	Umask                           string `json:"umask,omitempty"`
+	Description                     *string `json:"description,omitempty"`
+	IsContinuousAvailabilityEnabled *bool   `json:"is_continuous_availability_enabled,omitempty"`
+	IsEncryptionEnabled             *bool   `json:"is_encryption_enabled,omitempty"`
+	IsABEEnabled                    *bool   `json:"is_ABE_enabled,omitempty"`
+	IsBranchCacheEnabled            *bool   `json:"is_branch_cache_enabled,omitempty"`
+	OfflineAvailability             string  `json:"offline_availability,omitempty"`
+	Umask                           string  `json:"umask,omitempty"`
 }
 
 // SMBShare details about a SMB Share

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -32,6 +32,17 @@ type SMBShareCreate struct {
 	Umask                           string `json:"umask,omitempty"`
 }
 
+// SMBShareModify defines struct for modifying SMB share
+type SMBShareModify struct {
+	Description                     string `json:"description,omitempty"`
+	IsContinuousAvailabilityEnabled bool   `json:"is_continuous_availability_enabled,omitempty"`
+	IsEncryptionEnabled             bool   `json:"is_encryption_enabled,omitempty"`
+	IsABEEnabled                    bool   `json:"is_ABE_enabled,omitempty"`
+	IsBranchCacheEnabled            bool   `json:"is_branch_cache_enabled,omitempty"`
+	OfflineAvailability             string `json:"offline_availability,omitempty"`
+	Umask                           string `json:"umask,omitempty"`
+}
+
 // SMBShare details about a SMB Share
 type SMBShare struct {
 	ID                              string `json:"id"`

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -62,3 +62,23 @@ type SMBShare struct {
 func (share *SMBShare) Fields() []string {
 	return []string{"id", "name", "file_system_id", "path", "description", "is_continuous_availability_enabled", "is_encryption_enabled", "is_ABE_enabled", "is_branch_cache_enabled", "offline_availability", "umask", "offline_availability_l10n"}
 }
+
+// SMBShareAce defines struct for SMB ACE
+type SMBShareAce struct {
+	TrusteeType string `json:"trustee_type"`
+	TrusteeName string `json:"trustee_name"`
+	AccessLevel string `json:"access_level"`
+	AccessType  string `json:"access_type"`
+}
+
+// ModifySMBAcl defines struct for modifying SMB ACL
+type ModifySMBShareAcl struct {
+	Aces       []SMBShareAce `json:"aces,omitempty"`
+	AddAces    []SMBShareAce `json:"add_aces,omitempty"`
+	RemoveAces []SMBShareAce `json:"remove_aces,omitempty"`
+}
+
+// SMBShareAcl defines struct for SMB ACL
+type SMBShareAcl struct {
+	Aces []SMBShareAce `json:"aces"`
+}

--- a/smb_share_types.go
+++ b/smb_share_types.go
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package gopowerstore
+
+// SMBShare details about a SMB Share
+type SMBShare struct {
+	ID                              string `json:"id"`
+	FileSystemID                    string `json:"file_system_id"`
+	Name                            string `json:"name"`
+	Path                            string `json:"path"`
+	Description                     string `json:"description"`
+	IsContinuousAvailabilityEnabled bool   `json:"is_continuous_availability_enabled"`
+	IsEncryptionEnabled             bool   `json:"is_encryption_enabled"`
+	IsABEEnabled                    bool   `json:"is_ABE_enabled"`
+	IsBranchCacheEnabled            bool   `json:"is_branch_cache_enabled"`
+	OfflineAvailability             string `json:"offline_availability"`
+	Umask                           string `json:"umask"`
+	OfflineAvailabilityL10N         string `json:"offline_availability_l10n"`
+}
+
+func (share *SMBShare) Fields() []string {
+	return []string{"id", "name", "file_system_id", "path", "description", "is_continuous_availability_enabled", "is_encryption_enabled", "is_ABE_enabled", "is_branch_cache_enabled", "offline_availability", "umask", "offline_availability_l10n"}
+}


### PR DESCRIPTION
# GitHub Issues
PR is raised to add the CRUD operations for SMB share

| GitHub Issue # |
| -------------- |
|https://github.com/dell/terraform-provider-powerstore/issues/120 |

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility

## Description of your changes:
The support is added for the CRUD operations for SMB share along with setting/getting ACL.

![image](https://github.com/user-attachments/assets/39942a6b-29ea-4634-971a-ae6699a1d96b)
