### PR TITLE
Handled returning fields based on array version for NAS server

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -406,7 +406,7 @@ func (c *ClientIMPL) GetFsByFilter(ctx context.Context, filter map[string]string
 
 func GetNASFields(arrayVerion float32) []string {
 	var fields []string
-	fields = []string{"id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n"}
+	fields = []string{"id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "file_systems", "health_details", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n"}
 
 	if arrayVerion > 3.6 {
 		fields = append(fields, "is_dr_test")

--- a/fs.go
+++ b/fs.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/dell/gopowerstore/api"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -48,9 +49,18 @@ func getNfsServerDefaultQueryParams(c Client) api.QueryParamsEncoder {
 // GetNASServers query and return all NAS servers
 func (c *ClientIMPL) GetNASServers(ctx context.Context) ([]NAS, error) {
 	var result []NAS
+	var qp api.QueryParamsEncoder
 	err := c.readPaginatedData(func(offset int) (api.RespMeta, error) {
 		var page []NAS
-		qp := getNASDefaultQueryParams(c)
+		arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
+		if err != nil {
+			log.Errorf("Couldn't find the array version %s", err.Error())
+		}
+		if arrayVerion > 3.6 {
+			qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+		} else {
+			qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+		}
 		qp.Offset(offset).Limit(paginationDefaultPageSize)
 		meta, err := c.APIClient().Query(
 			ctx,
@@ -72,7 +82,16 @@ func (c *ClientIMPL) GetNASServers(ctx context.Context) ([]NAS, error) {
 // GetNASByName query and return specific NAS by name
 func (c *ClientIMPL) GetNASByName(ctx context.Context, name string) (resp NAS, err error) {
 	var nasList []NAS
-	qp := getNASDefaultQueryParams(c)
+	var qp api.QueryParamsEncoder
+	arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
+	if err != nil {
+		log.Errorf("Couldn't find the array version %s", err.Error())
+	}
+	if arrayVerion > 3.6 {
+		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+	} else {
+		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+	}
 	qp.RawArg("name", fmt.Sprintf("eq.%s", name))
 	_, err = c.APIClient().Query(
 		ctx,
@@ -94,13 +113,23 @@ func (c *ClientIMPL) GetNASByName(ctx context.Context, name string) (resp NAS, e
 
 // GetNAS query and return specific NAS by id
 func (c *ClientIMPL) GetNAS(ctx context.Context, id string) (resp NAS, err error) {
+	var qp api.QueryParamsEncoder
+	arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
+	if err != nil {
+		log.Errorf("Couldn't find the array version %s", err.Error())
+	}
+	if arrayVerion > 3.6 {
+		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+	} else {
+		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
+	}
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
 			Method:      "GET",
 			Endpoint:    nasURL,
 			ID:          id,
-			QueryParams: getNASDefaultQueryParams(c),
+			QueryParams: qp,
 		},
 		&resp)
 	return resp, WrapErr(err)

--- a/fs.go
+++ b/fs.go
@@ -50,17 +50,17 @@ func getNfsServerDefaultQueryParams(c Client) api.QueryParamsEncoder {
 func (c *ClientIMPL) GetNASServers(ctx context.Context) ([]NAS, error) {
 	var result []NAS
 	var qp api.QueryParamsEncoder
+	var fields []string
 	err := c.readPaginatedData(func(offset int) (api.RespMeta, error) {
 		var page []NAS
 		arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
 		if err != nil {
 			log.Errorf("Couldn't find the array version %s", err.Error())
 		}
-		if arrayVerion > 3.6 {
-			qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-		} else {
-			qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-		}
+
+		fields = GetNASFields(arrayVerion)
+		qp = c.APIClient().QueryParams().Select(fields...)
+
 		qp.Offset(offset).Limit(paginationDefaultPageSize)
 		meta, err := c.APIClient().Query(
 			ctx,
@@ -83,15 +83,15 @@ func (c *ClientIMPL) GetNASServers(ctx context.Context) ([]NAS, error) {
 func (c *ClientIMPL) GetNASByName(ctx context.Context, name string) (resp NAS, err error) {
 	var nasList []NAS
 	var qp api.QueryParamsEncoder
+	var fields []string
 	arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
 	if err != nil {
 		log.Errorf("Couldn't find the array version %s", err.Error())
 	}
-	if arrayVerion > 3.6 {
-		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-	} else {
-		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-	}
+
+	fields = GetNASFields(arrayVerion)
+	qp = c.APIClient().QueryParams().Select(fields...)
+
 	qp.RawArg("name", fmt.Sprintf("eq.%s", name))
 	_, err = c.APIClient().Query(
 		ctx,
@@ -114,15 +114,15 @@ func (c *ClientIMPL) GetNASByName(ctx context.Context, name string) (resp NAS, e
 // GetNAS query and return specific NAS by id
 func (c *ClientIMPL) GetNAS(ctx context.Context, id string) (resp NAS, err error) {
 	var qp api.QueryParamsEncoder
+	var fields []string
 	arrayVerion, err := c.GetSoftwareMajorMinorVersion(ctx)
 	if err != nil {
 		log.Errorf("Couldn't find the array version %s", err.Error())
 	}
-	if arrayVerion > 3.6 {
-		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "is_dr_test", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-	} else {
-		qp = c.APIClient().QueryParams().Select("id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n")
-	}
+
+	fields = GetNASFields(arrayVerion)
+	qp = c.APIClient().QueryParams().Select(fields...)
+
 	_, err = c.APIClient().Query(
 		ctx,
 		RequestConfig{
@@ -402,4 +402,15 @@ func (c *ClientIMPL) GetFsByFilter(ctx context.Context, filter map[string]string
 		return meta, err
 	})
 	return result, err
+}
+
+func GetNASFields(arrayVerion float32) []string {
+	var fields []string
+	fields = []string{"id", "description", "name", "current_node_id", "operational_status", "current_preferred_IPv4_interface_id", "current_preferred_IPv6_interface_id", "nfs_servers", "preferred_node_id", "default_unix_user", "default_windows_user", "current_unix_directory_service", "is_username_translation_enabled", "is_auto_user_mapping_enabled", "production_IPv4_interface_id", "production_IPv6_interface_id", "backup_IPv4_interface_id", "backup_IPv6_interface_id", "protection_policy_id", "file_events_publishing_mode", "is_replication_destination", "is_production_mode_enabled", "operational_status_l10n", "current_unix_directory_service_l10n", "file_events_publishing_mode_l10n"}
+
+	if arrayVerion > 3.6 {
+		fields = append(fields, "is_dr_test")
+	}
+
+	return fields
 }

--- a/fs_test.go
+++ b/fs_test.go
@@ -280,3 +280,10 @@ func TestClientIMPL_GetFsByFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, fsID, resp[0].ID)
 }
+
+func Test_GetNASFields(t *testing.T) {
+	fields := GetNASFields(3.7)
+	assert.NotEmpty(t, fields)
+	fields = GetNASFields(3.5)
+	assert.NotEmpty(t, fields)
+}

--- a/fs_test.go
+++ b/fs_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	nasMockURL       = APIMockURL + nasURL
-	fsMockURL        = APIMockURL + fsURL
-	nfsMockServerURL = APIMockURL + nfsServerURL
+	nasMockURL                  = APIMockURL + nasURL
+	fsMockURL                   = APIMockURL + fsURL
+	nfsMockServerURL            = APIMockURL + nfsServerURL
+	apiSoftwareInstalledMockURL = APIMockURL + apiSoftwareInstalledURL
 )
 
 var (
@@ -286,4 +287,34 @@ func Test_GetNASFields(t *testing.T) {
 	assert.NotEmpty(t, fields)
 	fields = GetNASFields(3.5)
 	assert.NotEmpty(t, fields)
+}
+
+func Test_NASServersErr(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, nasID)
+	httpmock.RegisterResponder("GET", apiSoftwareInstalledMockURL,
+		httpmock.NewStringResponder(404, respData))
+	_, err := C.GetNASServers(context.Background())
+	assert.NotNil(t, err)
+}
+
+func Test_NASServerByIdErr(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, nasID)
+	httpmock.RegisterResponder("GET", apiSoftwareInstalledMockURL,
+		httpmock.NewStringResponder(404, respData))
+	_, err := C.GetNAS(context.Background(), nasID)
+	assert.NotNil(t, err)
+}
+
+func Test_NASServerByNameErr(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	respData := fmt.Sprintf(`[{"id": "%s"}]`, nasID)
+	httpmock.RegisterResponder("GET", apiSoftwareInstalledMockURL,
+		httpmock.NewStringResponder(404, respData))
+	_, err := C.GetNASByName(context.Background(), "test")
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility?
- [x] Have you updated the mocks for any Client functions that have been modified (mocks/Client.go)?

## Description of your changes:
The "is_dr_test" attribute in NAS Server, is not applicable to array versions 3.6 and below but is applicable to array versions above 3.6. Thus, the fields have to be returned based on array version.
