### PR TITLE
removing omitempty for bool values in flr attributes

### DIFF
--- a/fs_types.go
+++ b/fs_types.go
@@ -93,8 +93,8 @@ type FlrAttributes struct {
 	MinimumRetention     string `json:"minimum_retention,omitempty"`
 	DefaultRetention     string `json:"default_retention,omitempty"`
 	MaximumRetention     string `json:"maximum_retention,omitempty"`
-	AutoLock             bool   `json:"auto_lock"`
-	AutoDelete           bool   `json:"auto_delete"`
+	AutoLock             *bool   `json:"auto_lock,omitempty"`
+	AutoDelete           *bool   `json:"auto_delete,omitempty"`
 	PolicyInterval       int32  `json:"policy_interval,omitempty"`
 	HasProtectedFiles    bool   `json:"has_protected_files,omitempty"`
 	ClockTime            string `json:"clock_time,omitempty"`

--- a/fs_types.go
+++ b/fs_types.go
@@ -93,8 +93,8 @@ type FlrAttributes struct {
 	MinimumRetention     string `json:"minimum_retention,omitempty"`
 	DefaultRetention     string `json:"default_retention,omitempty"`
 	MaximumRetention     string `json:"maximum_retention,omitempty"`
-	AutoLock             bool   `json:"auto_lock,omitempty"`
-	AutoDelete           bool   `json:"auto_delete,omitempty"`
+	AutoLock             bool   `json:"auto_lock"`
+	AutoDelete           bool   `json:"auto_delete"`
 	PolicyInterval       int32  `json:"policy_interval,omitempty"`
 	HasProtectedFiles    bool   `json:"has_protected_files,omitempty"`
 	ClockTime            string `json:"clock_time,omitempty"`


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Common PR Checklist:

- [] Have you made sure that the code compiles?
- [X] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Did you run tests in a real Kubernetes cluster?
- [X] Have you maintained backward compatibility?
- [ ] Have you updated the mocks for any Client functions that have been modified (mocks/Client.go)?

## Description of your changes:
facing issue while setting the value as false. Due to omitempty it's value is getting omitted from the paylod and that is causing issue.
