### PR TITLE
Refactor update to headers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -97,7 +97,7 @@ type RespMeta struct {
 }
 
 type SafeHeader struct {
-	mu     sync.RWMutex
+	mu     *sync.RWMutex
 	header http.Header
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -103,6 +103,7 @@ type SafeHeader struct {
 
 func NewSafeHeader() *SafeHeader {
 	return &SafeHeader{
+		mu:     &sync.RWMutex{},
 		header: make(http.Header),
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -292,7 +292,7 @@ func (c *ClientIMPL) Query(
 		return meta, err
 	}
 
-	c.logger.Info(ctx, "Requesting a lock for API : [%s %s]\n", config.Method, requestURL)
+	c.logger.Debug(ctx, "Requesting a lock for API : [%s %s]\n", config.Method, requestURL)
 	if err := c.apiThrottle.Acquire(ctx); err != nil {
 		return meta, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -96,24 +96,24 @@ type RespMeta struct {
 	Pagination PaginationInfo
 }
 
-type safeHeader struct {
+type SafeHeader struct {
 	mu     sync.RWMutex
 	header http.Header
 }
 
-func NewSafeHeader() *safeHeader {
-	return &safeHeader{
+func NewSafeHeader() *SafeHeader {
+	return &SafeHeader{
 		header: make(http.Header),
 	}
 }
 
-func (s *safeHeader) SetHeader(h http.Header) {
+func (s *SafeHeader) SetHeader(h http.Header) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.header = h.Clone() // clone to avoid external mutations
 }
 
-func (s *safeHeader) GetHeader() http.Header {
+func (s *SafeHeader) GetHeader() http.Header {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	h := s.header.Clone()
@@ -148,7 +148,7 @@ type ClientIMPL struct {
 	httpClient        *http.Client
 	defaultTimeout    int64
 	requestIDKey      ContextKey
-	customHTTPHeaders *safeHeader
+	customHTTPHeaders *SafeHeader
 	logger            Logger
 	apiThrottle       TimeoutSemaphoreInterface
 	loginMutex        sync.Mutex

--- a/api/api.go
+++ b/api/api.go
@@ -291,6 +291,7 @@ func (c *ClientIMPL) Query(
 		return meta, err
 	}
 
+	c.logger.Info(ctx, "%sAsking for LOCK for : %v\n", traceMsg, req.Method+" "+req.URL.String()+" ctx deadine : ")
 	if err := c.apiThrottle.Acquire(ctx); err != nil {
 		return meta, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -292,6 +292,7 @@ func (c *ClientIMPL) Query(
 		return meta, err
 	}
 
+	c.logger.Info(ctx, "Requesting a lock for API : [%s %s]\n", config.Method, requestURL)
 	if err := c.apiThrottle.Acquire(ctx); err != nil {
 		return meta, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -291,7 +291,6 @@ func (c *ClientIMPL) Query(
 		return meta, err
 	}
 
-	c.logger.Info(ctx, "%sAsking for LOCK for : %v\n", traceMsg, req.Method+" "+req.URL.String()+" ctx deadine : ")
 	if err := c.apiThrottle.Acquire(ctx); err != nil {
 		return meta, err
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -253,7 +253,7 @@ func TestClientIMPL_SetLogger(t *testing.T) {
 }
 
 func TestClientIMPL_GetCustomHTTPHeaders(t *testing.T) {
-	c := ClientIMPL{}
+	c := ClientIMPL{customHTTPHeaders: NewSafeHeader()}
 
 	want := http.Header{
 		"foo": {"bar"},
@@ -339,7 +339,7 @@ func Test_replaceSensitiveHeaderInfo(t *testing.T) {
 type stubTypeWithMetaData struct{}
 
 func (s stubTypeWithMetaData) MetaData() http.Header {
-	h := make(http.Header)
+	h := NewSafeHeader().GetHeader()
 	h.Set("foo", "bar")
 	return h
 }

--- a/api/throttling.go
+++ b/api/throttling.go
@@ -74,11 +74,11 @@ func (ts *TimeoutSemaphore) Acquire(ctx context.Context) error {
 			ts.Logger.Debug(ctx, "acquired lock successfully")
 			return nil
 		case <-ctx.Done():
-			msg := "failed to acquire lock (ctx), timeout expired"
+			msg := "failed to acquire lock (ctx) for API call, timeout expired"
 			ts.Logger.Error(ctx, msg)
 			return &TimeoutSemaphoreError{msg}
 		case <-acquireCtx.Done():
-			msg := "failed to acquire lock (acquireCtx), timeout expired"
+			msg := "failed to acquire lock (acquireCtx) for API call, timeout expired"
 			ts.Logger.Error(ctx, msg)
 			return &TimeoutSemaphoreError{msg}
 		}

--- a/api/throttling.go
+++ b/api/throttling.go
@@ -60,9 +60,10 @@ func (ts *TimeoutSemaphore) Acquire(ctx context.Context) error {
 	// find the min timeout between default timeout and context timeout
 	timeout := ts.Timeout
 	ctxTimeout, _ := ctx.Deadline()
-	ts.Logger.Info(ctx, "timeout value : ", timeout.String(), time.Until(ctxTimeout).String())
-	if time.Until(ctxTimeout) < timeout {
-		timeout = time.Until(ctxTimeout)
+	timeUntil := time.Until(ctxTimeout)
+	ts.Logger.Info(ctx, "default timeout and context timeout : ", timeout.String(), timeUntil.String())
+	if timeUntil > 0 && timeUntil < timeout {
+		timeout = timeUntil
 		ts.Logger.Info(ctx, "using context timeout for acquire lock : ", timeout.String())
 	}
 

--- a/api/throttling.go
+++ b/api/throttling.go
@@ -61,10 +61,8 @@ func (ts *TimeoutSemaphore) Acquire(ctx context.Context) error {
 	timeout := ts.Timeout
 	ctxTimeout, _ := ctx.Deadline()
 	timeUntil := time.Until(ctxTimeout)
-	ts.Logger.Info(ctx, "default timeout and context timeout : ", timeout.String(), timeUntil.String())
 	if timeUntil > 0 && timeUntil < timeout {
 		timeout = timeUntil
-		ts.Logger.Info(ctx, "using context timeout for acquire lock : ", timeout.String())
 	}
 
 	var cancelFunc func()

--- a/api/throttling.go
+++ b/api/throttling.go
@@ -60,26 +60,26 @@ func (ts *TimeoutSemaphore) Acquire(ctx context.Context) error {
 	// find the min timeout between default timeout and context timeout
 	timeout := ts.Timeout
 	ctxTimeout, _ := ctx.Deadline()
-	ts.Logger.Info(ctx, "timeout value : ", timeout, time.Until(ctxTimeout))
+	ts.Logger.Info(ctx, "timeout value : ", timeout.String(), time.Until(ctxTimeout).String())
 	if time.Until(ctxTimeout) < timeout {
 		timeout = time.Until(ctxTimeout)
-		ts.Logger.Info(ctx, "using context timeout for acquire lock : ", timeout)
+		ts.Logger.Info(ctx, "using context timeout for acquire lock : ", timeout.String())
 	}
 
 	var cancelFunc func()
-	acquireCtx, cancelFunc := context.WithTimeout(ctx, ts.Timeout)
+	acquireCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 	defer cancelFunc()
 	for {
 		select {
 		case ts.Semaphore <- struct{}{}:
-			ts.Logger.Debug(ctx, "acquire a lock")
+			ts.Logger.Debug(ctx, "acquired lock successfully")
 			return nil
 		case <-ctx.Done():
-			msg := "lock is acquire failed (ctx), timeout expired"
+			msg := "failed to acquire lock (ctx), timeout expired"
 			ts.Logger.Error(ctx, msg)
 			return &TimeoutSemaphoreError{msg}
 		case <-acquireCtx.Done():
-			msg := "lock is acquire failed (acquireCtx), timeout expired"
+			msg := "failed to acquire lock (acquireCtx), timeout expired"
 			ts.Logger.Error(ctx, msg)
 			return &TimeoutSemaphoreError{msg}
 		}

--- a/api/throttling.go
+++ b/api/throttling.go
@@ -60,6 +60,7 @@ func (ts *TimeoutSemaphore) Acquire(ctx context.Context) error {
 	// find the min timeout between default timeout and context timeout
 	timeout := ts.Timeout
 	ctxTimeout, _ := ctx.Deadline()
+	ts.Logger.Info(ctx, "timeout value : ", timeout, time.Until(ctxTimeout))
 	if time.Until(ctxTimeout) < timeout {
 		timeout = time.Until(ctxTimeout)
 		ts.Logger.Info(ctx, "using context timeout for acquire lock : ", timeout)

--- a/api/throttling_test.go
+++ b/api/throttling_test.go
@@ -48,4 +48,11 @@ func TestSemaphore(t *testing.T) {
 	go f(1, context.Background(), ts)
 	err = f(2, context.Background(), ts)
 	assert.Nil(t, err)
+
+	// main context timeout < default timeout function
+	ts = NewTimeoutSemaphore(2, 1, &defaultLogger{})
+	testCtx, _ := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second))
+	go f(1, testCtx, ts)
+	err = f(2, testCtx, ts)
+	assert.Nil(t, err)
 }

--- a/api/throttling_test.go
+++ b/api/throttling_test.go
@@ -51,7 +51,8 @@ func TestSemaphore(t *testing.T) {
 
 	// main context timeout < default timeout function
 	ts = NewTimeoutSemaphore(2, 1, &defaultLogger{})
-	testCtx, _ := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second))
+	testCtx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second))
+	defer cancelFunc()
 	go f(1, testCtx, ts)
 	err = f(2, testCtx, ts)
 	assert.Nil(t, err)

--- a/fs_types.go
+++ b/fs_types.go
@@ -20,6 +20,8 @@ package gopowerstore
 
 import (
 	"net/http"
+
+	"github.com/dell/gopowerstore/api"
 )
 
 // NASServerOperationalStatusEnum NAS lifecycle state.
@@ -111,7 +113,7 @@ const (
 // MetaData returns the metadata headers.
 func (fc *FsCreate) MetaData() http.Header {
 	fc.once.Do(func() {
-		fc.metadata = make(http.Header)
+		fc.metadata = api.NewSafeHeader().GetHeader()
 	})
 	return fc.metadata
 }
@@ -170,7 +172,7 @@ type FsClone struct {
 // MetaData returns the metadata headers.
 func (fc *FsClone) MetaData() http.Header {
 	fc.once.Do(func() {
-		fc.metadata = make(http.Header)
+		fc.metadata = api.NewSafeHeader().GetHeader()
 	})
 	return fc.metadata
 }

--- a/volume_types.go
+++ b/volume_types.go
@@ -20,6 +20,8 @@ package gopowerstore
 
 import (
 	"net/http"
+
+	"github.com/dell/gopowerstore/api"
 )
 
 // VolumeStateEnum Volume life cycle states.
@@ -236,7 +238,7 @@ type VolumeClone struct {
 // MetaData returns the metadata headers.
 func (vc *VolumeClone) MetaData() http.Header {
 	vc.once.Do(func() {
-		vc.metadata = make(http.Header)
+		vc.metadata = api.NewSafeHeader().GetHeader()
 	})
 	return vc.metadata
 }

--- a/volume_types.go
+++ b/volume_types.go
@@ -201,7 +201,7 @@ type VolumeComputeDifferencesResponse struct {
 // MetaData returns the metadata headers.
 func (vc *VolumeCreate) MetaData() http.Header {
 	vc.once.Do(func() {
-		vc.metadata = make(http.Header)
+		vc.metadata = api.NewSafeHeader().GetHeader()
 	})
 	return vc.metadata
 }


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
|https://github.com/dell/csm/issues/1742) |


# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained backward compatibility?
- [ ] Have you updated the mocks for any Client functions that have been modified (mocks/Client.go)?

## Description of your changes:
Setting custom headers in gopowerstore was updating a map in a thread unsafe way. If there was a burst of API calls, it caused the controller pods to crash/panic due to concurrent map writes. Changes include a thread-safe way of updating the headers. 

Another change in throttling code to create a new context and not overwrite the original context. Monitor both the context and timeout on the shorter one so as to not create lengthy contexts. If the operation did fail, the caller (mostly the provisioner) will issue another call for the same operation. 

Testing done:
1. Unit tests
```
coverage: 91.7% of statements
ok      github.com/dell/gopowerstore    1.390s  coverage: 91.7% of statements
coverage: 90.9% of statements
ok      github.com/dell/gopowerstore/api        8.369s  coverage: 90.9% of statements
```
3. Ran shared NFS and iSCSI provisioning of volumes to the order of about 400 volumes, using cert-csi (test scaling). Verified there are no controller pod crashes. In the past, about 100+ would often panic the controller pod. 
4. Ran provisioning on OCP and K8S clusters. 
