### PR TITLE
Added FSCreationLimitReached Error

### DIFF
--- a/gopowerstore_types.go
+++ b/gopowerstore_types.go
@@ -29,6 +29,9 @@ import (
 // RequestConfig represents options for request
 type RequestConfig api.RequestConfig
 
+// naslimitRegex is used to check if the error message contains a limit of file systems for the NAS server
+var naslimitRegex = regexp.MustCompile(`limit of \d+ file systems for the NAS server`)
+
 // RenderRequestConfig returns internal struct with request config
 func (rc RequestConfig) RenderRequestConfig() api.RequestConfig {
 	return api.RequestConfig(rc)
@@ -143,8 +146,7 @@ func (err *APIError) VolumeAlreadyRemovedFromVolumeGroup() bool {
 
 // FSCreationLimitReached returns true if API error indicate that file system creation limit has been reached
 func (err *APIError) FSCreationLimitReached() bool {
-	re := regexp.MustCompile(`limit of \d+ file systems for the NAS server`)
-	return err.StatusCode == http.StatusUnprocessableEntity && re.MatchString(err.Message)
+	return err.StatusCode == http.StatusUnprocessableEntity && naslimitRegex.MatchString(err.Message)
 }
 
 // NewNotFoundError returns new VolumeIsNotExistError

--- a/gopowerstore_types.go
+++ b/gopowerstore_types.go
@@ -140,6 +140,11 @@ func (err *APIError) VolumeAlreadyRemovedFromVolumeGroup() bool {
 	return err.StatusCode == http.StatusUnprocessableEntity && strings.Contains(err.Message, "not part")
 }
 
+// FSCreationLimitReached returns true if API error indicate that file system creation limit has been reached
+func (err *APIError) FSCreationLimitReached() bool {
+	return err.StatusCode == http.StatusUnprocessableEntity && strings.Contains(err.Message, "limit of 125 file systems for the NAS server")
+}
+
 // NewNotFoundError returns new VolumeIsNotExistError
 func NewNotFoundError() APIError {
 	return notFoundError()

--- a/gopowerstore_types.go
+++ b/gopowerstore_types.go
@@ -20,6 +20,7 @@ package gopowerstore
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/dell/gopowerstore/api"
@@ -142,7 +143,8 @@ func (err *APIError) VolumeAlreadyRemovedFromVolumeGroup() bool {
 
 // FSCreationLimitReached returns true if API error indicate that file system creation limit has been reached
 func (err *APIError) FSCreationLimitReached() bool {
-	return err.StatusCode == http.StatusUnprocessableEntity && strings.Contains(err.Message, "limit of 125 file systems for the NAS server")
+	re := regexp.MustCompile(`limit of \d+ file systems for the NAS server`)
+	return err.StatusCode == http.StatusUnprocessableEntity && re.MatchString(err.Message)
 }
 
 // NewNotFoundError returns new VolumeIsNotExistError

--- a/gopowerstore_types_test.go
+++ b/gopowerstore_types_test.go
@@ -77,29 +77,32 @@ func TestAPIError_VolumeAlreadyRemovedFromVolumeGroup(t *testing.T) {
 }
 
 func TestAPIError_FSCreationLimitReached(t *testing.T) {
-	apiError := NewAPIError()
-
 	// Case 1: Wrong status code
+	apiError := NewAPIError()
 	apiError.StatusCode = http.StatusBadRequest
 	apiError.Message = "The limit of 125 file systems for the NAS server has been reached"
 	assert.False(t, apiError.FSCreationLimitReached())
 
 	// Case 2: Correct status, but unrelated message
+	apiError = NewAPIError()
 	apiError.StatusCode = http.StatusUnprocessableEntity
 	apiError.Message = "some unrelated error message"
 	assert.False(t, apiError.FSCreationLimitReached())
 
 	// Case 3: Correct status and matching message
+	apiError = NewAPIError()
 	apiError.StatusCode = http.StatusUnprocessableEntity
 	apiError.Message = "The limit of 125 file systems for the NAS server has been reached"
 	assert.True(t, apiError.FSCreationLimitReached())
 
 	// Case 4: Correct status and message contains code
+	apiError = NewAPIError()
 	apiError.StatusCode = http.StatusUnprocessableEntity
-	apiError.Message = "error code 0xE08010080451: The limit of 125 file systems for the NAS server"
+	apiError.Message = "New file system can not be created. The limit of 125 file systems for the NAS server TEST has been reached."
 	assert.True(t, apiError.FSCreationLimitReached())
 
 	// Case 5: Leading/trailing whitespace (optional robustness)
+	apiError = NewAPIError()
 	apiError.StatusCode = http.StatusUnprocessableEntity
 	apiError.Message = "   The limit of 125 file systems for the NAS server   "
 	assert.True(t, apiError.FSCreationLimitReached())


### PR DESCRIPTION
# PR Submission checklist

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1758|

# Common PR Checklist:

- [x] Have you made sure that the code compiles?
- [x] Have you commented your code, particularly in hard-to-understand areas?
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Have you maintained backward compatibility?
- [ ] Have you updated the mocks for any Client functions that have been modified (mocks/Client.go)?

## Description of your changes:
Added FSCreationLimitReached() method in APIError to correctly detect NAS FS creation limit errors using:
- HTTP 422 status
- Message substring "limit of 125 file systems for the NAS server"
